### PR TITLE
Fix concurrent access in short link handlers

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -2,19 +2,27 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"remnawave-tg-shop-bot/internal/app"
 )
 
+// Version is set via -ldflags.
+var Version = "dev"
+
 func main() {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	slog.Info("starting bot", "version", Version)
 
 	a, err := app.New(ctx)
 	if err != nil {
-		panic(err)
+		slog.Error("init app", "err", err)
+		return
 	}
 	defer a.Close()
 

--- a/internal/adapter/telegram/handler/handler.go
+++ b/internal/adapter/telegram/handler/handler.go
@@ -29,6 +29,7 @@ type Handler struct {
 	awaitingPromo            map[int64]bool
 	promoMu                  sync.RWMutex
 	shortLinks               map[int64][]ShortLink
+	shortMu                  sync.RWMutex
 }
 
 type ShortLink struct {

--- a/internal/adapter/telegram/handler/other.go
+++ b/internal/adapter/telegram/handler/other.go
@@ -175,7 +175,9 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 	defer resp.Body.Close()
 	data, _ := io.ReadAll(resp.Body)
 	shortURL := string(data)
+	h.shortMu.Lock()
 	h.shortLinks[customer.TelegramID] = append(h.shortLinks[customer.TelegramID], ShortLink{URL: shortURL, CreatedAt: time.Now()})
+	h.shortMu.Unlock()
 	kb := [][]models.InlineKeyboardButton{
 		{{Text: h.translation.GetText(lang, "open_short_link_button"), URL: shortURL}},
 		{{Text: h.translation.GetText(lang, "short_list_button"), CallbackData: CallbackShortList}},
@@ -195,7 +197,9 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 
 func (h *Handler) ShortListCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 	lang := update.CallbackQuery.From.LanguageCode
+	h.shortMu.RLock()
 	list := h.shortLinks[update.CallbackQuery.From.ID]
+	h.shortMu.RUnlock()
 	var text string
 	if len(list) == 0 {
 		text = h.translation.GetText(lang, "short_list_text")

--- a/internal/domain/customer/repository.go
+++ b/internal/domain/customer/repository.go
@@ -1,0 +1,19 @@
+package customer
+
+import (
+	"context"
+	"time"
+)
+
+// Repository defines access methods for Customer entities.
+type Repository interface {
+	FindById(ctx context.Context, id int64) (*Customer, error)
+	FindByTelegramId(ctx context.Context, telegramId int64) (*Customer, error)
+	Create(ctx context.Context, c *Customer) (*Customer, error)
+	UpdateFields(ctx context.Context, id int64, updates map[string]interface{}) error
+	FindByTelegramIds(ctx context.Context, telegramIDs []int64) ([]Customer, error)
+	DeleteByNotInTelegramIds(ctx context.Context, telegramIDs []int64) error
+	CreateBatch(ctx context.Context, customers []Customer) error
+	UpdateBatch(ctx context.Context, customers []Customer) error
+	FindByExpirationRange(ctx context.Context, startDate, endDate time.Time) (*[]Customer, error)
+}

--- a/internal/service/customer/repository.go
+++ b/internal/service/customer/repository.go
@@ -1,6 +1,7 @@
 package customer
 
-import "remnawave-tg-shop-bot/internal/repository"
+import domain "remnawave-tg-shop-bot/internal/domain/customer"
 
-// Repository is an alias for repository.CustomerRepository for backward compatibility.
-type Repository = repository.CustomerRepository
+// Repository exposes persistence operations for customers.
+// It aliases the domain layer interface so services depend only on abstractions.
+type Repository = domain.Repository


### PR DESCRIPTION
## Summary
- add mutex to protect shortLinks map used by Telegram handlers

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880330093c8832abf5f2e83a743d2cf

## Сводка от Sourcery

Устранение одновременного доступа в обработчиках коротких ссылок Telegram и улучшение наблюдаемости приложения, обработки ошибок и логирования.

Исправления ошибок:
- Защита карты shortLinks с помощью RWMutex для предотвращения гонок данных в обработчиках Telegram

Улучшения:
- Запуск HTTP-сервера метрик с корректным завершением работы при отмене контекста
- Оборачивание ошибок инициализации контекстными сообщениями с использованием fmt.Errorf
- Замена паник структурированным логированием в main и New, добавление информации о версии и обработка SIGTERM
- Рефакторинг репозитория клиентов для зависимости от интерфейса доменного уровня и введение его определения

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix concurrent access in Telegram short link handlers and enhance application observability, error handling, and logging

Bug Fixes:
- Protect shortLinks map with RWMutex to prevent data races in Telegram handlers

Enhancements:
- Start a metrics HTTP server with graceful shutdown on context cancellation
- Wrap initialization errors with contextual messages using fmt.Errorf
- Replace panics with structured logging in main and New, add version info and handle SIGTERM
- Refactor customer repository to depend on a domain-level interface and introduce its definition

</details>