### PR TITLE
Add cron scheduling with tests

### DIFF
--- a/internal/app/cron_test.go
+++ b/internal/app/cron_test.go
@@ -1,0 +1,38 @@
+package app_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+func TestCronRunsJob(t *testing.T) {
+	c := cron.New(cron.WithSeconds())
+
+	var ran atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+
+	_, err := c.AddFunc("@every 1s", func() {
+		ran.Store(true)
+		cancel()
+	})
+	if err != nil {
+		t.Fatalf("add func: %v", err)
+	}
+
+	c.Start()
+	<-ctx.Done()
+	stopCtx := c.Stop()
+	select {
+	case <-stopCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("cron did not stop")
+	}
+
+	if !ran.Load() {
+		t.Fatal("job did not run")
+	}
+}


### PR DESCRIPTION
## Summary
- run subscription notifications daily using a cron job
- start cron on app startup and stop it with context
- verify cron scheduling with an integration test

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68804c3082b8832a9a47852e5cd9c911

## Сводка от Sourcery

Добавлено планирование по cron для ежедневного запуска службы уведомлений о подписке и управление её жизненным циклом внутри приложения, с сопутствующим тестом для проверки выполнения задачи и завершения работы.

Новые возможности:
- Планирование ежедневных уведомлений о подписках с помощью cron-задания в 16:00 UTC

Улучшения:
- Инициализация и управление жизненным циклом cron при запуске приложения и отмене контекста

Тесты:
- Добавлен интеграционный тест для проверки выполнения cron-задания и корректного завершения работы

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add cron scheduling to run subscription notification service daily and manage its lifecycle within the application, with an accompanying test to verify job execution and shutdown.

New Features:
- Schedule daily subscription notifications using a cron job at 16:00 UTC

Enhancements:
- Initialize and manage cron lifecycle on app startup and context cancellation

Tests:
- Add integration test to verify cron job execution and graceful shutdown

</details>