### PR TITLE
Fix context propagation in handlers

### DIFF
--- a/internal/adapter/telegram/handler/payment_handlers.go
+++ b/internal/adapter/telegram/handler/payment_handlers.go
@@ -112,7 +112,7 @@ func (h *Handler) SellCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 	}
 }
 
-func (h *Handler) PaymentCallbackHandler(_ context.Context, b *bot.Bot, update *models.Update) {
+func (h *Handler) PaymentCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 	chatID, msgID, ok := callbackChatMessage(update)
 	if !ok {
 		slog.Error("callback message missing")
@@ -137,7 +137,7 @@ func (h *Handler) PaymentCallbackHandler(_ context.Context, b *bot.Bot, update *
 		price = config.Price(month)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	customer, err := h.customerRepository.FindByTelegramId(ctx, chatID)
 	if err != nil {
@@ -318,7 +318,7 @@ func (h *Handler) PayFromBalanceCallbackHandler(ctx context.Context, b *bot.Bot,
 	data := parseCallbackData(update.CallbackQuery.Data)
 	month, _ := strconv.Atoi(data["month"])
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	customer, err := h.customerRepository.FindByTelegramId(ctxTimeout, chatID)
 	if err != nil || customer == nil {


### PR DESCRIPTION
## Summary
- use the passed context when creating timeouts in payment callbacks
- add a unit test ensuring the handler propagates context

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68804c2ae284832abf00bd345b20c62a

## Сводка от Sourcery

Исправлена передача контекста в обработчиках платежей Telegram путем переключения на переданный контекст для таймаутов и добавлен тест для проверки того, что репозитории и мессенджер получают правильный контекст.

Исправления ошибок:
- Исправлена передача контекста путем использования переданного контекста при создании таймаутов в обработчиках платежей.

Улучшения:
- Обновлены PaymentCallbackHandler и PayFromBalanceCallbackHandler для использования входящего контекста для таймаутов вместо context.Background.

Тесты:
- Добавлен модульный тест для проверки передачи контекста через репозитории и мессенджер в обработчике обратного вызова платежей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix context propagation in telegram payment handlers by switching to the passed context for timeouts and adding a test to ensure repositories and messenger receive the correct context

Bug Fixes:
- Fix context propagation by using the passed context when creating timeouts in payment handlers

Enhancements:
- Update PaymentCallbackHandler and PayFromBalanceCallbackHandler to use the incoming context for timeouts instead of context.Background

Tests:
- Add unit test to verify context propagation through repositories and messenger in payment callback handler

</details>