### PR TITLE
Initialize bot handlers

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,9 +13,18 @@ import (
 	"github.com/robfig/cron/v3"
 	"log/slog"
 
+	"remnawave-tg-shop-bot/internal/adapter/payment/cryptopay"
+	"remnawave-tg-shop-bot/internal/adapter/payment/yookassa"
+	"remnawave-tg-shop-bot/internal/adapter/remnawave"
+	tgHandler "remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+	tgMessenger "remnawave-tg-shop-bot/internal/adapter/telegram/messenger"
 	"remnawave-tg-shop-bot/internal/observability"
+	"remnawave-tg-shop-bot/internal/pkg/cache"
 	"remnawave-tg-shop-bot/internal/pkg/config"
 	"remnawave-tg-shop-bot/internal/pkg/translation"
+	pgrepo "remnawave-tg-shop-bot/internal/repository/pg"
+	"remnawave-tg-shop-bot/internal/service/payment"
+	syncsvc "remnawave-tg-shop-bot/internal/service/sync"
 )
 
 // App groups dependencies of the bot.
@@ -50,6 +59,24 @@ func New(ctx context.Context) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create bot: %w", err)
 	}
+
+	customerRepo := pgrepo.NewCustomerRepository(pool)
+	purchaseRepo := pgrepo.NewPurchaseRepository(pool)
+	referralRepo := pgrepo.NewReferralRepository(pool)
+	promoRepo := pgrepo.NewPromocodeRepository(pool)
+	promoUsageRepo := pgrepo.NewPromocodeUsageRepository(pool)
+	c := cache.NewCache(time.Minute)
+
+	remClient := remnawave.NewClient(config.RemnawaveUrl(), config.RemnawaveToken(), config.RemnawaveMode())
+	messenger := tgMessenger.NewBotMessenger(b)
+	cryptoClient := cryptopay.NewCryptoPayClient(config.CryptoPayUrl(), config.CryptoPayToken())
+	yookasaClient := yookasa.NewClient(config.YookasaUrl(), config.YookasaShopId(), config.YookasaSecretKey())
+
+	paymentSvc := payment.NewPaymentService(tm, purchaseRepo, remClient, customerRepo, messenger, cryptoClient, yookasaClient, referralRepo, promoRepo, promoUsageRepo, c)
+	syncSvc := syncsvc.NewSyncService(remClient, customerRepo)
+
+	h := tgHandler.NewHandler(syncSvc, paymentSvc, tm, customerRepo, purchaseRepo, cryptoClient, yookasaClient, referralRepo, promoRepo, promoUsageRepo, c)
+	initHandlers(b, h)
 
 	metricsSrv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.GetHealthCheckPort()),

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+)
+
+func initHandlers(b *bot.Bot, h *handler.Handler) {
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/start", bot.MatchTypeExact, h.StartCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/menu", bot.MatchTypeExact, h.MenuCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/help", bot.MatchTypeExact, h.HelpCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/promo", bot.MatchTypeExact, h.PromoCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/connect", bot.MatchTypeExact, h.ConnectCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/sync", bot.MatchTypeExact, h.SyncUsersCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackStart, bot.MatchTypePrefix, h.StartCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackConnect, bot.MatchTypePrefix, h.ConnectCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackBuy, bot.MatchTypePrefix, h.BuyCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackSell, bot.MatchTypePrefix, h.SellCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPayment, bot.MatchTypePrefix, h.PaymentCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackBalance, bot.MatchTypePrefix, h.BalanceCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackTopup, bot.MatchTypePrefix, h.TopupCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackTopupMethod, bot.MatchTypePrefix, h.TopupMethodCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPayFromBal, bot.MatchTypePrefix, h.PayFromBalanceCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackTrial, bot.MatchTypePrefix, h.TrialCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackActivateTrial, bot.MatchTypePrefix, h.ActivateTrialCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackReferral, bot.MatchTypePrefix, h.ReferralCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackReferralStats, bot.MatchTypePrefix, h.ReferralStatsCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoCodes, bot.MatchTypePrefix, h.PromoCodesCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoCreate, bot.MatchTypePrefix, h.PromoCreateCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoEnter, bot.MatchTypePrefix, h.PromoEnterCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoList, bot.MatchTypePrefix, h.PromoListCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoFreeze, bot.MatchTypePrefix, h.PromoFreezeCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoUnfreeze, bot.MatchTypePrefix, h.PromoUnfreezeCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoConfirmationDelete, bot.MatchTypePrefix, h.PromoDeleteConfirmationCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackPromoDelete, bot.MatchTypePrefix, h.PromoDeleteCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackOther, bot.MatchTypePrefix, h.OtherCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackFAQ, bot.MatchTypePrefix, h.FAQCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackTrafficLimit, bot.MatchTypePrefix, h.TrafficLimitCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackKeys, bot.MatchTypePrefix, h.KeysCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackQR, bot.MatchTypePrefix, h.QRCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackShortLink, bot.MatchTypePrefix, h.ShortLinkCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackShortList, bot.MatchTypePrefix, h.ShortListCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackLocations, bot.MatchTypePrefix, h.LocationsCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackRegenKey, bot.MatchTypePrefix, h.RegenKeyCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, handler.CallbackProxy, bot.MatchTypePrefix, h.ProxyCallbackHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+
+	b.RegisterHandlerMatchFunc(func(upd *models.Update) bool {
+		if upd.Message == nil {
+			return false
+		}
+		return h.IsAwaitingPromo(upd.Message.Chat.ID)
+	}, h.PromoCodeMessageHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+}

--- a/internal/app/init_handlers_test.go
+++ b/internal/app/init_handlers_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
+	"remnawave-tg-shop-bot/internal/pkg/translation"
+)
+
+type fakeCustomerRepo struct{ calls int }
+
+func (f *fakeCustomerRepo) FindById(ctx context.Context, id int64) (*domaincustomer.Customer, error) {
+	return nil, nil
+}
+func (f *fakeCustomerRepo) FindByTelegramId(ctx context.Context, id int64) (*domaincustomer.Customer, error) {
+	f.calls++
+	return &domaincustomer.Customer{TelegramID: id}, nil
+}
+func (f *fakeCustomerRepo) Create(ctx context.Context, c *domaincustomer.Customer) (*domaincustomer.Customer, error) {
+	return c, nil
+}
+func (f *fakeCustomerRepo) UpdateFields(ctx context.Context, id int64, updates map[string]interface{}) error {
+	return nil
+}
+func (f *fakeCustomerRepo) FindByTelegramIds(ctx context.Context, ids []int64) ([]domaincustomer.Customer, error) {
+	return nil, nil
+}
+func (f *fakeCustomerRepo) DeleteByNotInTelegramIds(ctx context.Context, ids []int64) error {
+	return nil
+}
+func (f *fakeCustomerRepo) CreateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
+	return nil
+}
+func (f *fakeCustomerRepo) UpdateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
+	return nil
+}
+func (f *fakeCustomerRepo) FindByExpirationRange(ctx context.Context, startDate, endDate time.Time) (*[]domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func TestInitHandlers(t *testing.T) {
+	b, err := bot.New("1:1", bot.WithSkipGetMe(), bot.WithNotAsyncHandlers())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tm := translation.GetInstance()
+	if err := tm.InitDefaultTranslations(); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &fakeCustomerRepo{}
+	h := handler.NewHandler(nil, nil, tm, repo, nil, nil, nil, nil, nil, nil, nil)
+
+	initHandlers(b, h)
+
+	upd := &models.Update{
+		ID: 1,
+		Message: &models.Message{
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1, LanguageCode: "en"},
+			Text:     "/connect",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/connect")}},
+		},
+	}
+	b.ProcessUpdate(context.Background(), upd)
+	if repo.calls == 0 {
+		t.Fatalf("command handler not executed")
+	}
+
+	repo.calls = 0
+	upd = &models.Update{
+		ID: 2,
+		CallbackQuery: &models.CallbackQuery{
+			ID:      "cb",
+			From:    models.User{ID: 1, LanguageCode: "en"},
+			Data:    handler.CallbackConnect,
+			Message: models.MaybeInaccessibleMessage{Message: &models.Message{ID: 1, Chat: models.Chat{ID: 1}}},
+		},
+	}
+	b.ProcessUpdate(context.Background(), upd)
+	if repo.calls == 0 {
+		t.Fatalf("callback handler not executed")
+	}
+}


### PR DESCRIPTION
## Summary
- create an initHandlers function that registers all command and callback handlers
- wire handler and services in app.New and apply middlewares
- test that handlers are triggered for sample message and callback

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68804c201e70832a9ee0b3853c7518c2

## Сводка от Sourcery

Инициализирует и регистрирует все обработчики команд и коллбэков Telegram-бота и подключает их к запуску приложения

Новые возможности:
- Введена функция `initHandlers` для регистрации обработчиков команд и коллбэков Telegram с использованием промежуточного ПО (middleware)
- Подключена инициализация обработчиков и сервисов в `app.New`, включая настройку репозиториев, клиентов и сервисов

Тесты:
- Добавлен тест `init_handlers_test` для проверки корректности срабатывания обработчиков команд и коллбэков

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize and register all Telegram bot command and callback handlers and wire them into the application startup

New Features:
- Introduce initHandlers to register Telegram command and callback handlers with middleware
- Wire handler and service initialization into app.New including repositories, clients, and services setup

Tests:
- Add init_handlers_test to verify that command and callback handlers are triggered correctly

</details>