### PR TITLE
Fix start referral arg parsing

### DIFF
--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -39,22 +39,25 @@ func (h *Handler) StartCommandHandler(ctx context.Context, b *bot.Bot, update *m
 		}
 
 		if strings.Contains(update.Message.Text, "ref_") {
-			arg := strings.Split(update.Message.Text, " ")[1]
-			if strings.HasPrefix(arg, "ref_") {
-				code := strings.TrimPrefix(arg, "ref_")
-				referrerId, err := strconv.ParseInt(code, 10, 64)
-				if err != nil {
-					slog.Error("error parsing referrer id", "err", err)
-					return
-				}
-				_, err = h.customerRepository.FindByTelegramId(ctx, referrerId)
-				if err == nil {
-					_, err := h.referralRepository.Create(ctx, referrerId, existingCustomer.TelegramID)
+			parts := strings.Split(update.Message.Text, " ")
+			if len(parts) > 1 {
+				arg := parts[1]
+				if strings.HasPrefix(arg, "ref_") {
+					code := strings.TrimPrefix(arg, "ref_")
+					referrerId, err := strconv.ParseInt(code, 10, 64)
 					if err != nil {
-						slog.Error("error creating referral", "err", err)
+						slog.Error("error parsing referrer id", "err", err)
 						return
 					}
-					slog.Info("referral created", "referrerId", utils.MaskHalfInt64(referrerId), "refereeId", utils.MaskHalfInt64(existingCustomer.TelegramID))
+					_, err = h.customerRepository.FindByTelegramId(ctx, referrerId)
+					if err == nil {
+						_, err := h.referralRepository.Create(ctx, referrerId, existingCustomer.TelegramID)
+						if err != nil {
+							slog.Error("error creating referral", "err", err)
+							return
+						}
+						slog.Info("referral created", "referrerId", utils.MaskHalfInt64(referrerId), "refereeId", utils.MaskHalfInt64(existingCustomer.TelegramID))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- prevent panics when `/start` is issued without parameters

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_688053275b10832ab405b22280d84db3

## Сводка от Sourcery

Предотвратить панику в StartCommandHandler путем проверки наличия аргумента referral перед парсингом

Исправления ошибок:
- Добавить проверку, чтобы убедиться, что длина разделенных частей больше единицы перед доступом к аргументу referral
- Восстановить процесс создания реферала только тогда, когда предоставлен действительный код реферера

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent panic in StartCommandHandler by validating the presence of the referral argument before parsing

Bug Fixes:
- Add guard to ensure split parts length is greater than one before accessing referral argument
- Restore referral creation flow only when a valid referrer code is provided

</details>