### PR TITLE
Refactor app lifecycle

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -24,10 +24,9 @@ func main() {
 		slog.Error("init app", "err", err)
 		return
 	}
-	defer a.Close()
+	defer a.Shutdown(ctx)
 
-	a.Cron.Start()
-	defer a.Cron.Stop()
+	a.Start()
 
 	a.Bot.Start(ctx)
 }


### PR DESCRIPTION
## Summary
- remove unused imports from `internal/app/app.go`
- create named cache and scheduler variables
- add `Start` and `Shutdown` methods on `App`
- update main to use the new lifecycle helpers

## Testing
- `go build ./...`
- `go test ./...` *(fails: shortlink_test.go:55:6: stubCustomerRepo redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_68805a46fd50832ab43f3da259bdb4ea