### PR TITLE
Refactor stub repo for tests

### DIFF
--- a/internal/adapter/telegram/handler/payment_handlers_test.go
+++ b/internal/adapter/telegram/handler/payment_handlers_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 
-	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
 	domainpurchase "remnawave-tg-shop-bot/internal/domain/purchase"
 	"remnawave-tg-shop-bot/internal/pkg/cache"
 	"remnawave-tg-shop-bot/internal/pkg/translation"
@@ -19,37 +18,6 @@ import (
 )
 
 // stub implementations
-
-type stubCustomerRepo struct{ ctx context.Context }
-
-func (s *stubCustomerRepo) FindById(ctx context.Context, id int64) (*domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (s *stubCustomerRepo) FindByTelegramId(ctx context.Context, telegramId int64) (*domaincustomer.Customer, error) {
-	s.ctx = ctx
-	return &domaincustomer.Customer{ID: 1, TelegramID: telegramId, Language: "en", Balance: 0}, nil
-}
-func (s *stubCustomerRepo) Create(ctx context.Context, c *domaincustomer.Customer) (*domaincustomer.Customer, error) {
-	return c, nil
-}
-func (s *stubCustomerRepo) UpdateFields(ctx context.Context, id int64, updates map[string]interface{}) error {
-	return nil
-}
-func (s *stubCustomerRepo) FindByTelegramIds(ctx context.Context, telegramIDs []int64) ([]domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (s *stubCustomerRepo) DeleteByNotInTelegramIds(ctx context.Context, telegramIDs []int64) error {
-	return nil
-}
-func (s *stubCustomerRepo) CreateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
-	return nil
-}
-func (s *stubCustomerRepo) UpdateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
-	return nil
-}
-func (s *stubCustomerRepo) FindByExpirationRange(ctx context.Context, startDate, endDate time.Time) (*[]domaincustomer.Customer, error) {
-	return nil, nil
-}
 
 type stubPurchaseRepo struct {
 	ctxCreate context.Context

--- a/internal/adapter/telegram/handler/shortlink_test.go
+++ b/internal/adapter/telegram/handler/shortlink_test.go
@@ -52,31 +52,6 @@ func (dummyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}")), Header: make(http.Header), Request: req}, nil
 }
 
-type stubCustomerRepoSL struct{}
-
-func (stubCustomerRepoSL) FindById(context.Context, int64) (*domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoSL) FindByTelegramId(context.Context, int64) (*domaincustomer.Customer, error) {
-	link := "https://example.com"
-	return &domaincustomer.Customer{TelegramID: 1, SubscriptionLink: &link}, nil
-}
-func (stubCustomerRepoSL) Create(ctx context.Context, c *domaincustomer.Customer) (*domaincustomer.Customer, error) {
-	return c, nil
-}
-func (stubCustomerRepoSL) UpdateFields(context.Context, int64, map[string]interface{}) error {
-	return nil
-}
-func (stubCustomerRepoSL) FindByTelegramIds(context.Context, []int64) ([]domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoSL) DeleteByNotInTelegramIds(context.Context, []int64) error      { return nil }
-func (stubCustomerRepoSL) CreateBatch(context.Context, []domaincustomer.Customer) error { return nil }
-func (stubCustomerRepoSL) UpdateBatch(context.Context, []domaincustomer.Customer) error { return nil }
-func (stubCustomerRepoSL) FindByExpirationRange(context.Context, time.Time, time.Time) (*[]domaincustomer.Customer, error) {
-	return nil, nil
-}
-
 func TestShortLinkCallbackHandler_BodyClosedOnRetry(t *testing.T) {
 	rt := &testRoundTripper{}
 	oldTransport := http.DefaultTransport
@@ -89,8 +64,9 @@ func TestShortLinkCallbackHandler_BodyClosedOnRetry(t *testing.T) {
 		t.Fatalf("new bot: %v", err)
 	}
 
+	link := "https://example.com"
 	h := &Handler{
-		customerRepository: stubCustomerRepoSL{},
+		customerRepository: &stubCustomerRepo{customerByTelegramID: &domaincustomer.Customer{TelegramID: 1, SubscriptionLink: &link}},
 		shortLinks:         make(map[int64][]ShortLink),
 		translation:        &translation.Manager{},
 	}

--- a/internal/adapter/telegram/handler/stubs_test.go
+++ b/internal/adapter/telegram/handler/stubs_test.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"context"
+	"time"
+
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
+)
+
+// stubCustomerRepo is a test implementation of the customer repository.
+type stubCustomerRepo struct {
+	ctx context.Context
+	// customerByTelegramID is returned from FindByTelegramId when set.
+	customerByTelegramID *domaincustomer.Customer
+}
+
+func (s *stubCustomerRepo) FindById(ctx context.Context, id int64) (*domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (s *stubCustomerRepo) FindByTelegramId(ctx context.Context, telegramId int64) (*domaincustomer.Customer, error) {
+	s.ctx = ctx
+	if s.customerByTelegramID != nil {
+		return s.customerByTelegramID, nil
+	}
+	return &domaincustomer.Customer{ID: 1, TelegramID: telegramId, Language: "en", Balance: 0}, nil
+}
+
+func (s *stubCustomerRepo) Create(ctx context.Context, c *domaincustomer.Customer) (*domaincustomer.Customer, error) {
+	return c, nil
+}
+
+func (s *stubCustomerRepo) UpdateFields(ctx context.Context, id int64, updates map[string]interface{}) error {
+	return nil
+}
+
+func (s *stubCustomerRepo) FindByTelegramIds(ctx context.Context, telegramIDs []int64) ([]domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (s *stubCustomerRepo) DeleteByNotInTelegramIds(ctx context.Context, telegramIDs []int64) error {
+	return nil
+}
+
+func (s *stubCustomerRepo) CreateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
+	return nil
+}
+
+func (s *stubCustomerRepo) UpdateBatch(ctx context.Context, customers []domaincustomer.Customer) error {
+	return nil
+}
+
+func (s *stubCustomerRepo) FindByExpirationRange(ctx context.Context, startDate, endDate time.Time) (*[]domaincustomer.Customer, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- share stubCustomerRepo between tests
- use shared stub in payment_handlers_test and shortlink_test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688067e218a0832aac3ab4f0f9826143

## Сводка от Sourcery

Централизация и повторное использование `stubCustomerRepo` в тестах путем его извлечения в общий файл `stubs_test.go` и обновление существующих тестов `PaymentHandlers` и `ShortLink` для использования общей реализации.

Улучшения:
- Извлечение `stubCustomerRepo` в отдельный файл `stubs_test.go`
- Удаление дублирующихся определений `stubCustomerRepo` из `payment_handlers_test.go` и `shortlink_test.go`
- Настройка теста `ShortLink` для внедрения общего `stubCustomerRepo` с пользовательским возвращаемым значением `SubscriptionLink`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and reuse the stubCustomerRepo across tests by extracting it into a shared stubs_test.go file and updating existing PaymentHandlers and ShortLink tests to use the shared implementation

Enhancements:
- Extract stubCustomerRepo into a standalone stubs_test.go file
- Remove duplicated stubCustomerRepo definitions from payment_handlers_test.go and shortlink_test.go
- Configure ShortLink test to inject shared stubCustomerRepo with a custom SubscriptionLink return value

</details>