### PR TITLE
Fix start command referral parsing

### DIFF
--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -38,27 +38,22 @@ func (h *Handler) StartCommandHandler(ctx context.Context, b *bot.Bot, update *m
 			return
 		}
 
-		if strings.Contains(update.Message.Text, "ref_") {
-			parts := strings.Split(update.Message.Text, " ")
-			if len(parts) > 1 {
-				arg := parts[1]
-				if strings.HasPrefix(arg, "ref_") {
-					code := strings.TrimPrefix(arg, "ref_")
-					referrerId, err := strconv.ParseInt(code, 10, 64)
-					if err != nil {
-						slog.Error("error parsing referrer id", "err", err)
-						return
-					}
-					_, err = h.customerRepository.FindByTelegramId(ctx, referrerId)
-					if err == nil {
-						_, err := h.referralRepository.Create(ctx, referrerId, existingCustomer.TelegramID)
-						if err != nil {
-							slog.Error("error creating referral", "err", err)
-							return
-						}
-						slog.Info("referral created", "referrerId", utils.MaskHalfInt64(referrerId), "refereeId", utils.MaskHalfInt64(existingCustomer.TelegramID))
-					}
+		parts := strings.Fields(update.Message.Text)
+		if len(parts) > 1 && strings.HasPrefix(parts[1], "ref_") {
+			code := strings.TrimPrefix(parts[1], "ref_")
+			referrerId, err := strconv.ParseInt(code, 10, 64)
+			if err != nil {
+				slog.Error("error parsing referrer id", "err", err)
+				return
+			}
+			_, err = h.customerRepository.FindByTelegramId(ctx, referrerId)
+			if err == nil {
+				_, err := h.referralRepository.Create(ctx, referrerId, existingCustomer.TelegramID)
+				if err != nil {
+					slog.Error("error creating referral", "err", err)
+					return
 				}
+				slog.Info("referral created", "referrerId", utils.MaskHalfInt64(referrerId), "refereeId", utils.MaskHalfInt64(existingCustomer.TelegramID))
 			}
 		}
 	} else {

--- a/internal/adapter/telegram/handler/start_command_test.go
+++ b/internal/adapter/telegram/handler/start_command_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"remnawave-tg-shop-bot/internal/pkg/translation"
+)
+
+type startHTTPClient struct{}
+
+func (c *startHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	resp := &http.Response{StatusCode: http.StatusOK}
+	resp.Body = io.NopCloser(strings.NewReader(`{"ok":true,"result":{"message_id":1}}`))
+	return resp, nil
+}
+
+func TestStartCommandHandler_NoArgs(t *testing.T) {
+	trans := translation.GetInstance()
+	if err := trans.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+
+	repo := &stubCustomerRepo{}
+	h := &Handler{customerRepository: repo, translation: trans}
+
+	b, err := bot.New("token", bot.WithHTTPClient(time.Second, &startHTTPClient{}), bot.WithSkipGetMe())
+	if err != nil {
+		t.Fatalf("bot init: %v", err)
+	}
+
+	upd := &models.Update{
+		Message: &models.Message{
+			Chat:     models.Chat{ID: 1},
+			From:     &models.User{ID: 1, LanguageCode: "en", FirstName: "u"},
+			Text:     "/start",
+			Entities: []models.MessageEntity{{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: len("/start")}},
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), "k", "v")
+	h.StartCommandHandler(ctx, b, upd)
+
+	if repo.ctx.Value("k") != "v" {
+		t.Errorf("context not propagated")
+	}
+}


### PR DESCRIPTION
## Summary
- handle referral codes using safer string parsing
- test `/start` command without arguments

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688069d7855c832ab42f51e759fa073d

## Сводка от Sourcery

Улучшено распознавание реферальных кодов для команды `/start` и добавлен тест для обработки вызовов без аргументов

Исправления ошибок:
- Использовать разделение по полям и проверку префиксов вместо поиска по подстроке для корректного распознавания реферальных кодов

Улучшения:
- Заменить `strings.Contains` и `Split` на `strings.Fields` и `HasPrefix` для более безопасного разбора аргументов

Тесты:
- Добавлен модульный тест для проверки, что `StartCommandHandler` обрабатывает `/start` без аргументов и передает контекст

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve referral code parsing for the /start command and add a test for handling calls without arguments

Bug Fixes:
- Use fields-based splitting and prefix checks instead of raw substring search to correctly parse referral codes

Enhancements:
- Replace strings.Contains and Split with strings.Fields and HasPrefix for safer argument parsing

Tests:
- Add unit test to verify StartCommandHandler handles /start with no arguments and propagates context

</details>