### PR TITLE
Ensure cache goroutine shutdown

### DIFF
--- a/internal/adapter/telegram/handler/payment_handlers_test.go
+++ b/internal/adapter/telegram/handler/payment_handlers_test.go
@@ -67,7 +67,7 @@ func TestPaymentCallbackHandler_ContextPropagation(t *testing.T) {
 	custRepo := &stubCustomerRepo{}
 	purchRepo := &stubPurchaseRepo{}
 	messenger := &stubMessenger{}
-	cache := cache.NewCache(time.Minute)
+	cache := cache.NewCache(context.Background(), time.Minute)
 	defer cache.Close()
 	trans := translation.GetInstance()
 	paySvc := payment.NewPaymentService(trans, purchRepo, nil, custRepo, messenger, nil, nil, nil, nil, cache)


### PR DESCRIPTION
## Summary
- cancel cache cleanup goroutine via context
- pass context into cache and shutdown with defer
- adjust tests to use new `cache.NewCache` signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68806b835c24832aa471e167212a37fa