### PR TITLE
Update golangci config for v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v2.3
           args: --timeout=5m
       - name: Vet
         run: go vet ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: 1.59
+version: 2.1
 run:
   timeout: 5m
 linters:


### PR DESCRIPTION
## Summary
- use new syntax for golangci-lint config
- install golangci-lint v2 in CI

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68806d11fae0832a919a7227036fbf21