### PR TITLE
Fix Telegram edit error on topup

### DIFF
--- a/internal/adapter/telegram/handler/payment_handlers.go
+++ b/internal/adapter/telegram/handler/payment_handlers.go
@@ -264,12 +264,18 @@ func (h *Handler) TopupCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		},
 		{{Text: h.translation.GetText(lang, "back_button"), CallbackData: CallbackBalance}},
 	}
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	text := fmt.Sprintf(h.translation.GetText(lang, "topup_intro_text"), int(customer.Balance))
+	params := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
-		Text:        fmt.Sprintf(h.translation.GetText(lang, "topup_intro_text"), int(customer.Balance)),
+		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: keyboard},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, params)
 	if err != nil {
 		slog.Error("Error sending topup message", "err", err)
 	}

--- a/internal/adapter/telegram/handler/safe_edit.go
+++ b/internal/adapter/telegram/handler/safe_edit.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// inlineKeyboardEqual compares two inline keyboards for equality.
+func inlineKeyboardEqual(a, b *models.InlineKeyboardMarkup) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a.InlineKeyboard) != len(b.InlineKeyboard) {
+		return false
+	}
+	for i := range a.InlineKeyboard {
+		if len(a.InlineKeyboard[i]) != len(b.InlineKeyboard[i]) {
+			return false
+		}
+		for j := range a.InlineKeyboard[i] {
+			if a.InlineKeyboard[i][j] != b.InlineKeyboard[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// SafeEditMessageText edits a message if new text or keyboard differ from the current ones.
+// It also ignores the "message is not modified" telegram error.
+func SafeEditMessageText(ctx context.Context, b *bot.Bot, current *models.Message, params *bot.EditMessageTextParams) (*models.Message, error) {
+	var newMarkup *models.InlineKeyboardMarkup
+	switch m := params.ReplyMarkup.(type) {
+	case models.InlineKeyboardMarkup:
+		newMarkup = &m
+	case *models.InlineKeyboardMarkup:
+		newMarkup = m
+	}
+
+	if current != nil {
+		if current.Text == params.Text && inlineKeyboardEqual(current.ReplyMarkup, newMarkup) {
+			return current, nil
+		}
+	}
+
+	msg, err := b.EditMessageText(ctx, params)
+	if err != nil {
+		if errors.Is(err, bot.ErrorBadRequest) && strings.Contains(err.Error(), "message is not modified") {
+			return current, nil
+		}
+		return nil, err
+	}
+	return msg, nil
+}

--- a/tests/unit/handler/safe_edit_test.go
+++ b/tests/unit/handler/safe_edit_test.go
@@ -1,0 +1,86 @@
+package handler_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	handlerpkg "remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+)
+
+type recordClient struct {
+	calls  int
+	status int
+	resp   string
+}
+
+func (c *recordClient) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+	body := io.NopCloser(strings.NewReader(c.resp))
+	return &http.Response{StatusCode: c.status, Body: body, Header: make(http.Header), Request: req}, nil
+}
+
+func newBot(c *recordClient) (*bot.Bot, error) {
+	return bot.New("token", bot.WithHTTPClient(time.Second, c), bot.WithSkipGetMe())
+}
+
+func TestSafeEditMessageText_Skip(t *testing.T) {
+	client := &recordClient{status: http.StatusOK, resp: `{"ok":true,"result":{"message_id":1}}`}
+	b, err := newBot(client)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	kb := [][]models.InlineKeyboardButton{{{Text: "a", CallbackData: "1"}}}
+	old := &models.Message{Text: "text", ReplyMarkup: &models.InlineKeyboardMarkup{InlineKeyboard: kb}}
+	params := &bot.EditMessageTextParams{ChatID: 1, MessageID: 1, Text: "text", ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb}}
+
+	if _, err := handlerpkg.SafeEditMessageText(context.Background(), b, old, params); err != nil {
+		t.Fatalf("SafeEditMessageText returned error: %v", err)
+	}
+	if client.calls != 0 {
+		t.Fatalf("expected 0 calls, got %d", client.calls)
+	}
+}
+
+func TestSafeEditMessageText_Call(t *testing.T) {
+	client := &recordClient{status: http.StatusOK, resp: `{"ok":true,"result":{"message_id":1}}`}
+	b, err := newBot(client)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	kb := [][]models.InlineKeyboardButton{{{Text: "a", CallbackData: "1"}}}
+	old := &models.Message{Text: "text", ReplyMarkup: &models.InlineKeyboardMarkup{InlineKeyboard: kb}}
+	params := &bot.EditMessageTextParams{ChatID: 1, MessageID: 1, Text: "new", ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb}}
+
+	if _, err := handlerpkg.SafeEditMessageText(context.Background(), b, old, params); err != nil {
+		t.Fatalf("SafeEditMessageText returned error: %v", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", client.calls)
+	}
+}
+
+func TestSafeEditMessageText_IgnoreError(t *testing.T) {
+	resp := `{"ok":false,"error_code":400,"description":"Bad Request: message is not modified"}`
+	client := &recordClient{status: http.StatusOK, resp: resp}
+	b, err := newBot(client)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	params := &bot.EditMessageTextParams{ChatID: 1, MessageID: 1, Text: "t"}
+	if _, err := handlerpkg.SafeEditMessageText(context.Background(), b, nil, params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", client.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- add SafeEditMessageText helper for editing Telegram messages without triggering `message is not modified`
- use SafeEditMessageText in topup handler
- test SafeEditMessageText

## Testing
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688093a724a0832aa840f883ae5c635a

## Сводка от Sourcery

Добавление вспомогательной функции SafeEditMessageText для условного редактирования сообщений Telegram и игнорирования ошибок "message is not modified", а также ее интеграция в обработчик пополнения.

Новые возможности:
- Введена функция SafeEditMessageText для условного редактирования сообщений

Исправления ошибок:
- Предотвращение избыточных правок в Telegram и подавление ошибок "message is not modified"

Улучшения:
- Замена прямого вызова EditMessageText в обработчике пополнения на SafeEditMessageText

Тесты:
- Добавлены модульные тесты для SafeEditMessageText, охватывающие сценарии бездействия, вызова редактирования и подавления ошибок

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add SafeEditMessageText helper to conditionally edit Telegram messages and ignore "message is not modified" errors, and integrate it into the topup handler

New Features:
- Introduce SafeEditMessageText function for conditional message editing

Bug Fixes:
- Prevent redundant Telegram edits and suppress "message is not modified" errors

Enhancements:
- Replace direct EditMessageText call in the topup handler with SafeEditMessageText

Tests:
- Add unit tests for SafeEditMessageText covering no-op, edit invocation, and error suppression scenarios

</details>