### PR TITLE
Add connect button logic for mini-app

### DIFF
--- a/internal/adapter/telegram/handler/other.go
+++ b/internal/adapter/telegram/handler/other.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	"remnawave-tg-shop-bot/internal/pkg/config"
+	"remnawave-tg-shop-bot/internal/ui"
 )
 
 func (h *Handler) OtherCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
@@ -168,7 +169,7 @@ func (h *Handler) QRCallbackHandler(ctx context.Context, b *bot.Bot, update *mod
 		}
 	}()
 	data, _ := io.ReadAll(resp.Body)
-	kb := [][]models.InlineKeyboardButton{{{Text: h.translation.GetText(lang, "back_button"), CallbackData: CallbackOther}}}
+	kb := ui.ConnectKeyboard(lang, "back_button", CallbackOther)
 	chatID, _, ok := callbackChatMessage(update)
 	if !ok {
 		slog.Error("callback message missing")

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -291,14 +291,7 @@ func InitConfig() {
 		return isWebAppLinkEnabled
 	}()
 
-	conf.miniApp = func() string {
-		v := os.Getenv("MINI_APP_URL")
-		if v != "" {
-			return v
-		} else {
-			return ""
-		}
-	}()
+	conf.miniApp = strings.TrimSpace(os.Getenv("MINI_APP_URL"))
 
 	conf.trialTrafficLimit = mustEnvInt("TRIAL_TRAFFIC_LIMIT")
 

--- a/internal/ui/keyboard.go
+++ b/internal/ui/keyboard.go
@@ -6,18 +6,18 @@ import (
 	"remnawave-tg-shop-bot/internal/pkg/translation"
 )
 
+func makeConnectButton(miniAppURL, lang string) models.InlineKeyboardButton {
+	tm := translation.GetInstance()
+	if miniAppURL == "" {
+		return models.InlineKeyboardButton{Text: tm.GetText(lang, "connect_button"), CallbackData: "connect"}
+	}
+	return models.InlineKeyboardButton{Text: tm.GetText(lang, "connect_button"), URL: miniAppURL}
+}
+
 func ConnectKeyboard(lang, backKey, backCallback string) [][]models.InlineKeyboardButton {
 	tm := translation.GetInstance()
 	var kb [][]models.InlineKeyboardButton
-	if config.GetMiniAppURL() != "" {
-		kb = append(kb, []models.InlineKeyboardButton{
-			{Text: tm.GetText(lang, "connect_button"), WebApp: &models.WebAppInfo{URL: config.GetMiniAppURL()}},
-		})
-	} else {
-		kb = append(kb, []models.InlineKeyboardButton{
-			{Text: tm.GetText(lang, "connect_button"), CallbackData: "connect"},
-		})
-	}
+	kb = append(kb, []models.InlineKeyboardButton{makeConnectButton(config.GetMiniAppURL(), lang)})
 	kb = append(kb, []models.InlineKeyboardButton{{Text: tm.GetText(lang, backKey), CallbackData: backCallback}})
 	return kb
 }

--- a/internal/ui/keyboard_test.go
+++ b/internal/ui/keyboard_test.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"remnawave-tg-shop-bot/internal/pkg/translation"
+	"testing"
+)
+
+func TestMakeConnectButton(t *testing.T) {
+	tm := translation.GetInstance()
+	if err := tm.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+	btn := makeConnectButton("", "en")
+	if btn.CallbackData != "connect" || btn.URL != "" {
+		t.Fatalf("expected callback button, got %#v", btn)
+	}
+
+	url := "https://example.com"
+	btn = makeConnectButton(url, "en")
+	if btn.URL != url || btn.CallbackData != "" {
+		t.Fatalf("expected url button, got %#v", btn)
+	}
+}


### PR DESCRIPTION
## Summary
- trim spaces for `MINI_APP_URL`
- generate connect button via helper
- use helper in QR code menu
- test connect button generation

## Testing
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68809b1b2fac832a9366677105c1947a

## Сводка от Sourcery

Унифицировано создание кнопки подключения в пользовательском интерфейсе путем введения вспомогательной функции, удалены пробелы из MINI_APP_URL при инициализации конфигурации, реорганизованы построители клавиатур для использования вспомогательной функции, и добавлены модульные тесты для генерации кнопки подключения

Улучшения:
- Добавлена вспомогательная функция makeConnectButton для генерации кнопок подключения с колбэком или URL
- Реорганизованы ConnectKeyboard и обработчик QR-кодов для использования новой вспомогательной функции
- Упрощена конфигурация MINI_APP_URL путем удаления окружающих пробелов

Тесты:
- Добавлен модульный тест TestMakeConnectButton, охватывающий сценарии как с колбэком, так и с URL

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify connect button construction in the UI by introducing a helper, trim whitespace from MINI_APP_URL in config initialization, refactor keyboard builders to use the helper, and add unit tests for connect button generation

Enhancements:
- Add makeConnectButton helper to generate connect buttons with either callback or URL
- Refactor ConnectKeyboard and QR code handler to use the new helper
- Simplify MINI_APP_URL config by trimming surrounding whitespace

Tests:
- Add TestMakeConnectButton unit test covering both callback and URL scenarios

</details>