### PR TITLE
Fix golangci-lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.3
+          version: v1.59.1
           args: --config=.golangci.yml --timeout=5m
       - name: Vet
         run: go vet ./...
-      - name: Staticcheck
-        uses: dominikh/staticcheck-action@v1
-        with:
-          version: latest
       - name: Test build
         run: go build ./...
       - name: Unit tests


### PR DESCRIPTION
## Summary
- use golangci-lint-action v7 with version `v1.59.1`
- remove standalone staticcheck step

## Testing
- `golangci-lint run --config=.golangci.yml --timeout=5m`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880a562e114832a8aa0fada5cd3870f