### PR TITLE
Fix golangci-lint action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           go-version: '1.24'
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.59.1
+          version: v2.1
           args: --config=.golangci.yml --timeout=5m
       - name: Vet
         run: go vet ./...


### PR DESCRIPTION
## Summary
- upgrade golangci-lint GitHub Action to v8
- use golangci-lint v2.1

## Testing
- `golangci-lint run --config=.golangci.yml --timeout=5m`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880aa455684832aac292239859bdf06