### PR TITLE
Add shared test env helper

### DIFF
--- a/cmd/bot/main_test.go
+++ b/cmd/bot/main_test.go
@@ -1,23 +1,18 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"remnawave-tg-shop-bot/tests/testutils"
+)
 
 func TestMainSmoke(t *testing.T) {
-	t.Setenv("DISABLE_ENV_FILE", "true")
-	t.Setenv("ADMIN_TELEGRAM_IDS", "1")
-	t.Setenv("TELEGRAM_TOKEN", "t")
-	t.Setenv("TRIAL_TRAFFIC_LIMIT", "1")
-	t.Setenv("TRIAL_DAYS", "1")
+	testutils.SetTestEnv(t)
 	t.Setenv("PRICE_1", "10")
 	t.Setenv("PRICE_3", "30")
 	t.Setenv("PRICE_6", "50")
 	t.Setenv("REMNAWAVE_URL", "http://x")
-	t.Setenv("REMNAWAVE_TOKEN", "x")
 	t.Setenv("DATABASE_URL", "bad://")
 	t.Setenv("TRAFFIC_LIMIT", "100")
-	t.Setenv("REFERRAL_DAYS", "0")
-	t.Setenv("REFERRAL_BONUS", "0")
-	t.Setenv("CRYPTO_PAY_ENABLED", "false")
-	t.Setenv("TELEGRAM_STARS_ENABLED", "false")
 	main()
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -4,25 +4,19 @@ import (
 	"testing"
 
 	"remnawave-tg-shop-bot/internal/pkg/config"
+	"remnawave-tg-shop-bot/tests/testutils"
 )
 
 func TestInitConfigPrices(t *testing.T) {
-	t.Setenv("DISABLE_ENV_FILE", "true")
-	t.Setenv("ADMIN_TELEGRAM_IDS", "1")
+	testutils.SetTestEnv(t)
 	t.Setenv("TELEGRAM_TOKEN", "token")
-	t.Setenv("TRIAL_TRAFFIC_LIMIT", "1")
-	t.Setenv("TRIAL_DAYS", "1")
 	t.Setenv("PRICE_1", "10")
 	t.Setenv("PRICE_3", "30")
 	t.Setenv("PRICE_6", "50")
 	t.Setenv("REMNAWAVE_URL", "http://example.com")
 	t.Setenv("REMNAWAVE_TOKEN", "tok")
-	t.Setenv("DATABASE_URL", "db")
 	t.Setenv("TRAFFIC_LIMIT", "100")
-	t.Setenv("REFERRAL_DAYS", "0")
 	t.Setenv("REFERRAL_BONUS", "150")
-	t.Setenv("CRYPTO_PAY_ENABLED", "false")
-	t.Setenv("TELEGRAM_STARS_ENABLED", "false")
 
 	config.InitConfig()
 

--- a/tests/integration/remnawave_header_test.go
+++ b/tests/integration/remnawave_header_test.go
@@ -9,25 +9,13 @@ import (
 	"testing"
 
 	"remnawave-tg-shop-bot/internal/pkg/config"
+	"remnawave-tg-shop-bot/tests/testutils"
 )
 
 func TestHeaderTransport(t *testing.T) {
-	t.Setenv("DISABLE_ENV_FILE", "true")
-	t.Setenv("ADMIN_TELEGRAM_IDS", "1")
-	t.Setenv("TELEGRAM_TOKEN", "t")
-	t.Setenv("TRIAL_TRAFFIC_LIMIT", "1")
-	t.Setenv("TRIAL_DAYS", "1")
-	t.Setenv("PRICE_1", "1")
-	t.Setenv("PRICE_3", "1")
-	t.Setenv("PRICE_6", "1")
+	testutils.SetTestEnv(t)
 	t.Setenv("REMNAWAVE_URL", "")
-	t.Setenv("REMNAWAVE_TOKEN", "x")
-	t.Setenv("DATABASE_URL", "db")
-	t.Setenv("TRAFFIC_LIMIT", "1")
-	t.Setenv("REFERRAL_DAYS", "0")
 	t.Setenv("REFERRAL_BONUS", "0")
-	t.Setenv("CRYPTO_PAY_ENABLED", "false")
-	t.Setenv("TELEGRAM_STARS_ENABLED", "false")
 	t.Setenv("X_API_KEY", "key")
 
 	config.InitConfig()

--- a/tests/testutils/envsetup.go
+++ b/tests/testutils/envsetup.go
@@ -1,0 +1,24 @@
+package testutils
+
+import "testing"
+
+// SetTestEnv sets common environment variables required for tests.
+func SetTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DISABLE_ENV_FILE", "true")
+	t.Setenv("ADMIN_TELEGRAM_IDS", "1")
+	t.Setenv("TELEGRAM_TOKEN", "t")
+	t.Setenv("TRIAL_TRAFFIC_LIMIT", "1")
+	t.Setenv("TRIAL_DAYS", "1")
+	t.Setenv("PRICE_1", "1")
+	t.Setenv("PRICE_3", "1")
+	t.Setenv("PRICE_6", "1")
+	t.Setenv("REMNAWAVE_URL", "http://example.com")
+	t.Setenv("REMNAWAVE_TOKEN", "x")
+	t.Setenv("DATABASE_URL", "db")
+	t.Setenv("TRAFFIC_LIMIT", "1")
+	t.Setenv("REFERRAL_DAYS", "0")
+	t.Setenv("REFERRAL_BONUS", "0")
+	t.Setenv("CRYPTO_PAY_ENABLED", "false")
+	t.Setenv("TELEGRAM_STARS_ENABLED", "false")
+}


### PR DESCRIPTION
## Summary
- create `SetTestEnv` for reusing env vars in tests
- use `SetTestEnv` in integration and unit tests
- format and run tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880c05d361c832a8496fc44e605be98