### PR TITLE
Propagate context to SyncService

### DIFF
--- a/internal/adapter/telegram/handler/sync.go
+++ b/internal/adapter/telegram/handler/sync.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *Handler) SyncUsersCommandHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	h.syncService.Sync()
+	h.syncService.Sync(ctx)
 	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: update.Message.Chat.ID,
 		Text:   "Users synced",

--- a/internal/service/sync/sync.go
+++ b/internal/service/sync/sync.go
@@ -20,9 +20,8 @@ func NewSyncService(client *remnawave.Client, customerRepository custrepo.Reposi
 	}
 }
 
-func (s SyncService) Sync() {
+func (s SyncService) Sync(ctx context.Context) {
 	slog.Info("Starting sync")
-	ctx := context.Background()
 	var telegramIDs []int64
 	telegramIDsSet := make(map[int64]int64)
 	var mappedUsers []domaincustomer.Customer


### PR DESCRIPTION
## Summary
- accept context in `SyncService.Sync` and use it for database and API calls
- pass this context from telegram handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688301d10c5c832ab8d617fcd20e3173