### PR TITLE
Handle remnawave client creation errors

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -42,7 +42,11 @@ func main() {
 	promoRepo := pg.NewPromocodeRepository(a.Pool)
 	promoUsageRepo := pg.NewPromocodeUsageRepository(a.Pool)
 
-	remClient := remnawave.NewClient(config.RemnawaveUrl(), config.RemnawaveToken(), config.RemnawaveMode())
+	remClient, err := remnawave.NewClient(config.RemnawaveUrl(), config.RemnawaveToken(), config.RemnawaveMode())
+	if err != nil {
+		slog.Error("init remnawave client", "err", err)
+		return
+	}
 	cryptoClient := crypto.NewCryptoPayClient(config.CryptoPayUrl(), config.CryptoPayToken())
 	messenger := tgMessenger.NewBotMessenger(a.Bot)
 

--- a/internal/adapter/remnawave/client.go
+++ b/internal/adapter/remnawave/client.go
@@ -52,7 +52,7 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(r)
 }
 
-func NewClient(baseURL, token, mode string) *Client {
+func NewClient(baseURL, token, mode string) (*Client, error) {
 	xApiKey := config.GetXApiKey()
 	local := mode == "local"
 
@@ -66,9 +66,9 @@ func NewClient(baseURL, token, mode string) *Client {
 
 	api, err := remapi.NewClient(baseURL, remapi.StaticToken{Token: token}, remapi.WithClient(client))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return &Client{client: api}
+	return &Client{client: api}, nil
 }
 
 // NewClientWithAPI is a helper exported for tests.

--- a/tests/remnawave_header_test.go
+++ b/tests/remnawave_header_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	remnawave "remnawave-tg-shop-bot/internal/adapter/remnawave"
 	"remnawave-tg-shop-bot/internal/pkg/config"
 )
 
@@ -28,7 +29,10 @@ func TestHeaderTransport(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(srv.URL, "token", "local")
+	c, err := remnawave.NewClient(srv.URL, "token", "local")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
 	if err := c.Ping(context.Background()); err != nil {
 		t.Fatalf("ping: %v", err)
 	}


### PR DESCRIPTION
## Summary
- return an error from `NewClient`
- handle this error in `cmd/bot`
- adapt integration test to new constructor signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883017f6134832a9035ba9a1fd42b17