### PR TITLE
Add reusable customer repo stub

### DIFF
--- a/tests/customer_repository_test.go
+++ b/tests/customer_repository_test.go
@@ -1,38 +1,12 @@
 package tests
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	domain "remnawave-tg-shop-bot/internal/domain/customer"
 	svc "remnawave-tg-shop-bot/internal/service/customer"
+	"remnawave-tg-shop-bot/tests/stubs"
 )
 
-type stubCustomerRepoAlias struct{}
-
-func (stubCustomerRepoAlias) FindById(context.Context, int64) (*domain.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoAlias) FindByTelegramId(context.Context, int64) (*domain.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoAlias) Create(context.Context, *domain.Customer) (*domain.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoAlias) UpdateFields(context.Context, int64, map[string]interface{}) error {
-	return nil
-}
-func (stubCustomerRepoAlias) FindByTelegramIds(context.Context, []int64) ([]domain.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepoAlias) DeleteByNotInTelegramIds(context.Context, []int64) error { return nil }
-func (stubCustomerRepoAlias) CreateBatch(context.Context, []domain.Customer) error    { return nil }
-func (stubCustomerRepoAlias) UpdateBatch(context.Context, []domain.Customer) error    { return nil }
-func (stubCustomerRepoAlias) FindByExpirationRange(context.Context, time.Time, time.Time) (*[]domain.Customer, error) {
-	return nil, nil
-}
-
 func TestAlias(t *testing.T) {
-	var _ svc.Repository = stubCustomerRepoAlias{}
+	var _ svc.Repository = stubs.StubCustomerRepo{}
 }

--- a/tests/repository_repository_test.go
+++ b/tests/repository_repository_test.go
@@ -1,39 +1,12 @@
 package tests
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
 	"remnawave-tg-shop-bot/internal/repository"
+	"remnawave-tg-shop-bot/tests/stubs"
 )
 
-// stubCustomerRepo2 implements CustomerRepository for compile-time check
-type stubCustomerRepo2 struct{}
-
-func (stubCustomerRepo2) FindById(context.Context, int64) (*domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepo2) FindByTelegramId(context.Context, int64) (*domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepo2) Create(context.Context, *domaincustomer.Customer) (*domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepo2) UpdateFields(context.Context, int64, map[string]interface{}) error {
-	return nil
-}
-func (stubCustomerRepo2) FindByTelegramIds(context.Context, []int64) ([]domaincustomer.Customer, error) {
-	return nil, nil
-}
-func (stubCustomerRepo2) DeleteByNotInTelegramIds(context.Context, []int64) error      { return nil }
-func (stubCustomerRepo2) CreateBatch(context.Context, []domaincustomer.Customer) error { return nil }
-func (stubCustomerRepo2) UpdateBatch(context.Context, []domaincustomer.Customer) error { return nil }
-func (stubCustomerRepo2) FindByExpirationRange(context.Context, time.Time, time.Time) (*[]domaincustomer.Customer, error) {
-	return nil, nil
-}
-
 func TestInterfaceCompliance(t *testing.T) {
-	var _ repository.CustomerRepository = stubCustomerRepo2{}
+	var _ repository.CustomerRepository = stubs.StubCustomerRepo{}
 }

--- a/tests/stubs/customer_repo_stub.go
+++ b/tests/stubs/customer_repo_stub.go
@@ -1,0 +1,47 @@
+package stubs
+
+import (
+	"context"
+	"time"
+
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
+)
+
+// stubCustomerRepo provides empty implementations of all methods
+// of the customer repository interface. It is used only for
+// compile-time interface compliance checks in tests.
+type stubCustomerRepo struct{}
+
+// StubCustomerRepo is an exported alias of stubCustomerRepo so tests in
+// other packages can use it without exposing method implementations.
+type StubCustomerRepo = stubCustomerRepo
+
+func (stubCustomerRepo) FindById(context.Context, int64) (*domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (stubCustomerRepo) FindByTelegramId(context.Context, int64) (*domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (stubCustomerRepo) Create(context.Context, *domaincustomer.Customer) (*domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (stubCustomerRepo) UpdateFields(context.Context, int64, map[string]interface{}) error {
+	return nil
+}
+
+func (stubCustomerRepo) FindByTelegramIds(context.Context, []int64) ([]domaincustomer.Customer, error) {
+	return nil, nil
+}
+
+func (stubCustomerRepo) DeleteByNotInTelegramIds(context.Context, []int64) error { return nil }
+
+func (stubCustomerRepo) CreateBatch(context.Context, []domaincustomer.Customer) error { return nil }
+
+func (stubCustomerRepo) UpdateBatch(context.Context, []domaincustomer.Customer) error { return nil }
+
+func (stubCustomerRepo) FindByExpirationRange(context.Context, time.Time, time.Time) (*[]domaincustomer.Customer, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- add `stubCustomerRepo` implementation in a dedicated `tests/stubs` package
- replace duplicate stub structs in repository tests with the shared stub

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688301b18e64832ab240675e1b27bf60

## Сводка от Sourcery

Ввести переиспользуемую заглушку репозитория клиентов в тестах и рефакторинг существующих тестов для ее использования.

Улучшения:
- Добавить общую реализацию StubCustomerRepo в tests/stubs для соответствия интерфейсу во время компиляции
- Удалить дублирующиеся встроенные структуры-заглушки и объединить их в новую общую заглушку

Тесты:
- Обновить тесты репозитория и сервиса клиентов для использования общей StubCustomerRepo вместо локальных заглушек

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable customer repository stub in tests and refactor existing tests to use it

Enhancements:
- Add shared StubCustomerRepo implementation in tests/stubs for compile-time interface compliance
- Remove duplicate inline stub structs and consolidate them into the new shared stub

Tests:
- Update repository and customer service tests to use the shared StubCustomerRepo instead of local stubs

</details>