### PR TITLE
Handle config init errors

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -26,6 +26,11 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	if err := config.InitConfig(); err != nil {
+		slog.Error("init config", "err", err)
+		return
+	}
+
 	slog.Info("starting bot", "version", Version)
 
 	a, err := app.New(ctx)

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -10,7 +10,9 @@ import (
 )
 
 func main() {
-	config.InitConfig()
+	if err := config.InitConfig(); err != nil {
+		log.Fatalf("init config: %v", err)
+	}
 	ctx := context.Background()
 
 	pool, err := app.InitDatabase(ctx, config.DatabaseURL())

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,7 +30,6 @@ type App struct {
 }
 
 func New(ctx context.Context) (*App, error) {
-	config.InitConfig()
 
 	tm := translation.GetInstance()
 	if err := tm.InitDefaultTranslations(); err != nil {

--- a/tests/config_config_test.go
+++ b/tests/config_config_test.go
@@ -17,7 +17,9 @@ func TestInitConfigPrices(t *testing.T) {
 	t.Setenv("TRAFFIC_LIMIT", "100")
 	t.Setenv("REFERRAL_BONUS", "150")
 
-	config.InitConfig()
+	if err := config.InitConfig(); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
 
 	if config.Price(3) != 30 {
 		t.Fatalf("price3 expected 30, got %d", config.Price(3))

--- a/tests/remnawave_header_test.go
+++ b/tests/remnawave_header_test.go
@@ -17,7 +17,9 @@ func TestHeaderTransport(t *testing.T) {
 	t.Setenv("REFERRAL_BONUS", "0")
 	t.Setenv("X_API_KEY", "key")
 
-	config.InitConfig()
+	if err := config.InitConfig(); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
 
 	var gotKey, gotForward string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- update config helpers to return errors instead of panic
- return an error from `InitConfig`
- load configuration in `cmd/bot` and log failures
- update migration command and tests for new signature
- remove config initialization from `app.New`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883018f6578832abe14d52582bea68b

## Сводка от Sourcery

Сделать загрузку конфигурации надежной, заменив `panic` возвратом ошибок и обеспечив внешнюю обработку ошибок `InitConfig`.

Улучшения:
- Рефакторинг вспомогательных функций для работы с переменными окружения (mustEnv, mustEnvInt, envIntDefault) для возврата ошибок вместо `panic` при отсутствии или недопустимых значениях
- Изменить `InitConfig` для возврата ошибки и распространения всех ошибок валидации и парсинга
- Обновить команды `bot` и `migrate` для вызова `InitConfig` и обработки ошибок инициализации
- Удалить встроенную инициализацию конфигурации из `app.New` и требовать внешней загрузки конфигурации

Тесты:
- Обновить тесты конфигурации и заголовков `remnawave` для обработки новой сигнатуры возврата ошибок `InitConfig`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make configuration loading robust by replacing panics with error returns and ensuring InitConfig errors are handled externally

Enhancements:
- Refactor env helpers (mustEnv, mustEnvInt, envIntDefault) to return errors instead of panicking on missing or invalid values
- Change InitConfig to return an error and propagate all validation and parsing failures
- Update bot and migrate commands to call InitConfig and handle initialization errors
- Remove built-in config initialization from app.New and require external config loading

Tests:
- Update config and remnawave header tests to handle the new InitConfig error return signature

</details>