### PR TITLE
Use safe edit helpers in handlers

### DIFF
--- a/internal/adapter/telegram/handler/connect.go
+++ b/internal/adapter/telegram/handler/connect.go
@@ -80,7 +80,7 @@ func (h *Handler) ConnectCallbackHandler(ctx context.Context, b *bot.Bot, update
 	markup = append(markup, []models.InlineKeyboardButton{{Text: h.translation.GetText(langCode, "back_to_account_button"), CallbackData: CallbackStart}})
 
 	isDisabled := true
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,
@@ -91,7 +91,12 @@ func (h *Handler) ConnectCallbackHandler(ctx context.Context, b *bot.Bot, update
 		ReplyMarkup: models.InlineKeyboardMarkup{
 			InlineKeyboard: markup,
 		},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, params)
 
 	if err != nil {
 		slog.Error("Error sending connect message", "err", err)

--- a/internal/adapter/telegram/handler/other.go
+++ b/internal/adapter/telegram/handler/other.go
@@ -46,13 +46,18 @@ func (h *Handler) OtherCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        h.translation.GetText(lang, "other_menu_text"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, params)
 	if err != nil {
 		errMsg := err.Error()
 		if !strings.Contains(errMsg, "there is no text in the message to edit") {
@@ -100,13 +105,18 @@ func (h *Handler) simpleBack(ctx context.Context, b *bot.Bot, update *models.Upd
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, params)
 	if err != nil {
 		slog.Error("send simple back", "err", err)
 	}
@@ -252,13 +262,18 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		return
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	paramsShort := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        fmt.Sprintf(h.translation.GetText(lang, "short_created_text"), shortURL),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgShort *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgShort = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgShort, paramsShort)
 	if err != nil {
 		slog.Error("send short", "err", err)
 	}
@@ -291,13 +306,18 @@ func (h *Handler) ShortListCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	paramsList := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgList *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgList = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsgList, paramsList)
 	if err != nil {
 		slog.Error("send short list", "err", err)
 	}
@@ -324,13 +344,18 @@ func (h *Handler) ProxyCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	paramsProxy := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgProxy *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgProxy = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsgProxy, paramsProxy)
 	if err != nil {
 		slog.Error("send proxy", "err", err)
 	}

--- a/internal/adapter/telegram/handler/payment_handlers.go
+++ b/internal/adapter/telegram/handler/payment_handlers.go
@@ -66,7 +66,7 @@ func (h *Handler) BuyCallbackHandler(ctx context.Context, b *bot.Bot, update *mo
 	if customer != nil {
 		bal = int(customer.Balance)
 	}
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,
@@ -74,7 +74,12 @@ func (h *Handler) BuyCallbackHandler(ctx context.Context, b *bot.Bot, update *mo
 			InlineKeyboard: keyboard,
 		},
 		Text: fmt.Sprintf(h.translation.GetText(langCode, "choose_plan_text"), bal, config.Price1(), config.Price3(), config.Price6()),
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, params)
 
 	if err != nil {
 		slog.Error("Error sending buy message", "err", err)
@@ -99,13 +104,18 @@ func (h *Handler) SellCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 		{Text: h.translation.GetText(langCode, "back_button"), CallbackData: CallbackBuy},
 	})
 
-	_, err := b.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+	rmParams := &bot.EditMessageReplyMarkupParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ReplyMarkup: models.InlineKeyboardMarkup{
 			InlineKeyboard: keyboard,
 		},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageReplyMarkup(ctx, b, curMsg, rmParams)
 
 	if err != nil {
 		slog.Error("Error sending sell message", "err", err)
@@ -158,7 +168,7 @@ func (h *Handler) PaymentCallbackHandler(ctx context.Context, b *bot.Bot, update
 
 	langCode := update.CallbackQuery.From.LanguageCode
 
-	message, err := b.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+	rmParams2 := &bot.EditMessageReplyMarkupParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ReplyMarkup: models.InlineKeyboardMarkup{
@@ -169,7 +179,12 @@ func (h *Handler) PaymentCallbackHandler(ctx context.Context, b *bot.Bot, update
 				},
 			},
 		},
-	})
+	}
+	var curMsg2 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg2 = update.CallbackQuery.Message.Message
+	}
+	message, err := SafeEditMessageReplyMarkup(ctx, b, curMsg2, rmParams2)
 	if err != nil {
 		slog.Error("Error updating sell message", "err", err)
 		return
@@ -223,13 +238,18 @@ func (h *Handler) BalanceCallbackHandler(ctx context.Context, b *bot.Bot, update
 		{{Text: h.translation.GetText(lang, "back_to_account_button"), CallbackData: CallbackStart}},
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	paramsBalance := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: keyboard},
-	})
+	}
+	var curMsgB *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgB = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsgB, paramsBalance)
 	if err != nil {
 		slog.Error("Error sending balance message", "err", err)
 	}
@@ -305,11 +325,16 @@ func (h *Handler) TopupMethodCallbackHandler(ctx context.Context, b *bot.Bot, up
 	}
 	keyboard = append(keyboard, []models.InlineKeyboardButton{{Text: h.translation.GetText(lang, "back_button"), CallbackData: CallbackTopup}})
 
-	_, err := b.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+	rmParams3 := &bot.EditMessageReplyMarkupParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: keyboard},
-	})
+	}
+	var curMsg3 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg3 = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageReplyMarkup(ctx, b, curMsg3, rmParams3)
 	if err != nil {
 		slog.Error("Error sending topup methods", "err", err)
 	}

--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -42,13 +42,18 @@ func (h *Handler) ReferralCallbackHandler(ctx context.Context, b *bot.Bot, updat
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        h.translation.GetText(langCode, "referral_menu_text"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, params)
 	if err != nil {
 		slog.Error("Error sending referral menu", "err", err)
 	}
@@ -94,13 +99,18 @@ func (h *Handler) PromoCreateCallbackHandler(ctx context.Context, b *bot.Bot, up
 	}
 
 	if err != nil {
-		_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		errParams := &bot.EditMessageTextParams{
 			ChatID:      chatID,
 			MessageID:   msgID,
 			ParseMode:   models.ParseModeHTML,
 			Text:        h.translation.GetText(langCode, "insufficient_balance"),
 			ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-		})
+		}
+		var curMsg *models.Message
+		if update.CallbackQuery.Message.Message != nil {
+			curMsg = update.CallbackQuery.Message.Message
+		}
+		_, err = SafeEditMessageText(ctx, b, curMsg, errParams)
 		if err != nil {
 			slog.Error("Error sending insufficient_balance code msg", "err", err)
 		}
@@ -108,13 +118,18 @@ func (h *Handler) PromoCreateCallbackHandler(ctx context.Context, b *bot.Bot, up
 		return
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	okParams := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        fmt.Sprintf(h.translation.GetText(langCode, "promocode_created"), code),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsg2 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg2 = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg2, okParams)
 	if err != nil {
 		slog.Error("Error sending succesfully_created code msg", "err", err)
 	}
@@ -145,13 +160,18 @@ func (h *Handler) PromoEnterCallbackHandler(ctx context.Context, b *bot.Bot, upd
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	enterParams := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        h.translation.GetText(langCode, "enter_promocode_prompt"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgEnter *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgEnter = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgEnter, enterParams)
 	if err != nil {
 		slog.Error("Error sending enter_promocode_prompt code msg", "err", err)
 	}
@@ -200,13 +220,18 @@ func (h *Handler) ReferralStatsCallbackHandler(ctx context.Context, b *bot.Bot, 
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	statsParams := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        text,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgStats *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgStats = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgStats, statsParams)
 	if err != nil {
 		slog.Error("Error sending referral stats", "err", err)
 	}
@@ -237,13 +262,18 @@ func (h *Handler) PromoCodesCallbackHandler(ctx context.Context, b *bot.Bot, upd
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	codesParams := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        h.translation.GetText(langCode, "personal_codes_text"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgCodes *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgCodes = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgCodes, codesParams)
 	if err != nil {
 		slog.Error("Error sending promo codes menu", "err", err)
 	}
@@ -297,13 +327,18 @@ func (h *Handler) PromoListCallbackHandler(ctx context.Context, b *bot.Bot, upda
 
 	kb = append(kb, []models.InlineKeyboardButton{{Text: h.translation.GetText(langCode, "back_button"), CallbackData: CallbackPromoCodes}})
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	listParams := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		Text:        textBuilder.String(),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgList *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgList = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgList, listParams)
 	if err != nil {
 		slog.Error("Error sending promocode list", "err", err)
 	}
@@ -387,14 +422,19 @@ func (h *Handler) PromoDeleteConfirmationCallbackHandler(ctx context.Context, b 
 		kb := [][]models.InlineKeyboardButton{
 			{{Text: h.translation.GetText(langCode, "back_button"), CallbackData: CallbackPromoList}},
 		}
-		_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		activeParams := &bot.EditMessageTextParams{
 			ChatID:    chatID,
 			MessageID: msgID,
 			ParseMode: models.ParseModeHTML,
 			// TODO: Серега, нужен текст. БУКАВЫ
 			Text:        h.translation.GetText(langCode, "promo_active_when_delete"),
 			ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-		})
+		}
+		var curMsgActive *models.Message
+		if update.CallbackQuery.Message.Message != nil {
+			curMsgActive = update.CallbackQuery.Message.Message
+		}
+		_, err = SafeEditMessageText(ctx, b, curMsgActive, activeParams)
 		if err != nil {
 			slog.Error("Error sending promo_active_when_delete code msg", "err", err)
 		}
@@ -406,14 +446,19 @@ func (h *Handler) PromoDeleteConfirmationCallbackHandler(ctx context.Context, b 
 		{{Text: h.translation.GetText(langCode, "back_button"), CallbackData: CallbackPromoList}},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	confirmParams := &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,
 		// TODO: Серега, нужен текст. БУКАВЫ
 		Text:        h.translation.GetText(langCode, "promo_confirm_when_delete"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	var curMsgConfirm *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsgConfirm = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsgConfirm, confirmParams)
 	if err != nil {
 		slog.Error("Error sending promo_confirm_when_delete code msg", "err", err)
 	}

--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -122,13 +122,18 @@ func (h *Handler) StartCallbackHandler(ctx context.Context, b *bot.Bot, update *
 	inlineKeyboard := h.buildStartKeyboard(existingCustomer, langCode)
 
 	text := fmt.Sprintf(h.translation.GetText(langCode, "account_menu_text"), callback.From.FirstName) + "\n\n" + h.buildAccountInfo(ctxWithTime, existingCustomer, langCode)
-	_, err = b.EditMessageText(ctxWithTime, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:      callback.Message.Message.Chat.ID,
 		MessageID:   callback.Message.Message.ID,
 		ParseMode:   models.ParseModeHTML,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: inlineKeyboard},
 		Text:        text,
-	})
+	}
+	var curMsg *models.Message
+	if callback.Message.Message != nil {
+		curMsg = callback.Message.Message
+	}
+	_, err = SafeEditMessageText(ctxWithTime, b, curMsg, params)
 	if err != nil {
 		slog.Error("Error sending /start message", "err", err)
 	}

--- a/internal/adapter/telegram/handler/trial.go
+++ b/internal/adapter/telegram/handler/trial.go
@@ -36,7 +36,7 @@ func (h *Handler) TrialCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		Text:      h.translation.GetText(langCode, "trial_text"),
@@ -45,7 +45,12 @@ func (h *Handler) TrialCallbackHandler(ctx context.Context, b *bot.Bot, update *
 			{{Text: h.translation.GetText(langCode, "activate_trial_button"), CallbackData: CallbackActivateTrial}},
 			{{Text: h.translation.GetText(langCode, "back_to_account_button"), CallbackData: CallbackStart}},
 		}},
-	})
+	}
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, params)
 	if err != nil {
 		slog.Error("Error sending /trial message", "err", err)
 	}
@@ -79,13 +84,18 @@ func (h *Handler) ActivateTrialCallbackHandler(ctx context.Context, b *bot.Bot, 
 	}
 
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params2 := &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		Text:        h.translation.GetText(langCode, "trial_activated"),
 		ParseMode:   models.ParseModeHTML,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: ui.ConnectKeyboard(langCode, "back_to_account_button", CallbackStart)},
-	})
+	}
+	var curMsg2 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg2 = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg2, params2)
 	if err != nil {
 		slog.Error("Error sending /trial message", "err", err)
 	}

--- a/internal/adapter/telegram/handler/utils.go
+++ b/internal/adapter/telegram/handler/utils.go
@@ -90,7 +90,7 @@ func (h *Handler) promptPromoMonths(ctx context.Context, b *bot.Bot, msg *models
 	}
 
 	bal := int(customer.Balance)
-	_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params := &bot.EditMessageTextParams{
 		ChatID:    msg.Chat.ID,
 		MessageID: msg.ID,
 		ParseMode: models.ParseModeHTML,
@@ -98,7 +98,8 @@ func (h *Handler) promptPromoMonths(ctx context.Context, b *bot.Bot, msg *models
 		ReplyMarkup: models.InlineKeyboardMarkup{
 			InlineKeyboard: kb,
 		},
-	})
+	}
+	_, _ = SafeEditMessageText(ctx, b, msg, params)
 }
 
 func (h *Handler) promptPromoUses(ctx context.Context, b *bot.Bot, msg *models.Message, lang string) {
@@ -113,10 +114,11 @@ func (h *Handler) promptPromoUses(ctx context.Context, b *bot.Bot, msg *models.M
 		kb = append(kb, []models.InlineKeyboardButton{{Text: label, CallbackData: fmt.Sprintf("%s?u=%d", CallbackPromoCreate, u)}})
 	}
 	kb = append(kb, []models.InlineKeyboardButton{{Text: h.translation.GetText(lang, "back_button"), CallbackData: CallbackReferral}})
-	_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	params2 := &bot.EditMessageTextParams{
 		ChatID:      msg.Chat.ID,
 		MessageID:   msg.ID,
 		Text:        h.translation.GetText(lang, "promo_choose_uses"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
-	})
+	}
+	_, _ = SafeEditMessageText(ctx, b, msg, params2)
 }


### PR DESCRIPTION
## Summary
- avoid spamming Telegram API by using SafeEditMessageText/SafeEditMessageReplyMarkup
- update handlers to rely on safe edit helpers
- add tests for SafeEditMessageReplyMarkup

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688302158a40832ab1e2379c5c7ff232

## Сводка от Sourcery

Внедрить вспомогательные функции для безопасного редактирования текста сообщения и разметки ответа, чтобы предотвратить избыточные вызовы Telegram API, и обновить все обработчики для их использования.

Новые возможности:
- Добавить вспомогательную функцию SafeEditMessageReplyMarkup, которая условно редактирует разметку встроенной клавиатуры и игнорирует ошибки "message is not modified".
- Добавить вспомогательную функцию SafeEditMessageText для безопасного редактирования текста сообщения без избыточных запросов к API.

Улучшения:
- Заменить прямые вызовы EditMessageText и EditMessageReplyMarkup во всех обработчиках Telegram на вспомогательные функции безопасного редактирования, чтобы пропускать неизмененные правки.

Тесты:
- Добавить модульные тесты для SafeEditMessageReplyMarkup, охватывающие сценарии пропуска, вызова и игнорирования ошибок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce safe edit helper functions for message text and reply markup to prevent redundant Telegram API calls and update all handlers to use them.

New Features:
- Add SafeEditMessageReplyMarkup helper that conditionally edits inline keyboard markup and ignores "message is not modified" errors.
- Add SafeEditMessageText helper to safely edit message text without spamming the API.

Enhancements:
- Replace direct EditMessageText and EditMessageReplyMarkup calls in all Telegram handlers with safe edit helpers to skip unchanged edits.

Tests:
- Add unit tests for SafeEditMessageReplyMarkup covering skip, invocation, and error-ignoring scenarios.

</details>