### PR TITLE
Fix start callback message handler

### DIFF
--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -108,9 +108,16 @@ func (h *Handler) StartCallbackHandler(ctx context.Context, b *bot.Bot, update *
 	inlineKeyboard := h.buildStartKeyboard(existingCustomer, langCode)
 
 	text := fmt.Sprintf(h.translation.GetText(langCode, "account_menu_text"), callback.From.FirstName) + "\n\n" + h.buildAccountInfo(ctxWithTime, existingCustomer, langCode)
+
+	chatID, msgID, ok := callbackChatMessage(update)
+	if !ok {
+		slog.Error("callback message missing")
+		return
+	}
+
 	_, err = b.EditMessageText(ctxWithTime, &bot.EditMessageTextParams{
-		ChatID:      callback.Message.Message.Chat.ID,
-		MessageID:   callback.Message.Message.ID,
+		ChatID:      chatID,
+		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: inlineKeyboard},
 		Text:        text,


### PR DESCRIPTION
## Summary
- handle inaccessible callback message in StartCallbackHandler
- log an error and exit early if callback message is missing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688321ba6bd8832a978441979f3be95f