### PR TITLE
Implement short link cleanup in handler

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -66,6 +66,8 @@ func main() {
 
 	h := tgHandler.NewHandler(syncSvc, paySvc, tm, customerRepo, purchaseRepo, referralRepo, promoRepo, promoUsageRepo, a.Cache)
 
+	h.Start(ctx)
+
 	a.InitHandlers(h)
 
 	a.Start()


### PR DESCRIPTION
## Summary
- run background cleanup for short links in `Handler.Start`
- invoke `Start` from `cmd/bot`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68832742cf7c832aad0461fd5a75c9a6