### PR TITLE
Handle unmodified message error

### DIFF
--- a/internal/adapter/telegram/handler/connect.go
+++ b/internal/adapter/telegram/handler/connect.go
@@ -80,7 +80,11 @@ func (h *Handler) ConnectCallbackHandler(ctx context.Context, b *bot.Bot, update
 	markup = append(markup, []models.InlineKeyboardButton{{Text: h.translation.GetText(langCode, "back_to_account_button"), CallbackData: CallbackStart}})
 
 	isDisabled := true
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,

--- a/internal/adapter/telegram/handler/other.go
+++ b/internal/adapter/telegram/handler/other.go
@@ -46,7 +46,11 @@ func (h *Handler) OtherCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -100,7 +104,11 @@ func (h *Handler) simpleBack(ctx context.Context, b *bot.Bot, update *models.Upd
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -288,7 +296,11 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		return
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -327,7 +339,11 @@ func (h *Handler) ShortListCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -360,7 +376,11 @@ func (h *Handler) ProxyCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,

--- a/internal/adapter/telegram/handler/payment_handlers.go
+++ b/internal/adapter/telegram/handler/payment_handlers.go
@@ -66,7 +66,11 @@ func (h *Handler) BuyCallbackHandler(ctx context.Context, b *bot.Bot, update *mo
 	if customer != nil {
 		bal = int(customer.Balance)
 	}
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,
@@ -101,7 +105,11 @@ func (h *Handler) SellCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 
 	text := fmt.Sprintf(h.translation.GetText(langCode, "selected_months"), month)
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		ParseMode: models.ParseModeHTML,
@@ -227,7 +235,11 @@ func (h *Handler) BalanceCallbackHandler(ctx context.Context, b *bot.Bot, update
 		{{Text: h.translation.GetText(lang, "back_to_account_button"), CallbackData: CallbackStart}},
 	}
 
-	_, err := b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err := SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,

--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -44,7 +44,11 @@ func (h *Handler) ReferralCallbackHandler(ctx context.Context, b *bot.Bot, updat
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -97,7 +101,11 @@ func (h *Handler) PromoCreateCallbackHandler(ctx context.Context, b *bot.Bot, up
 	}
 
 	if err != nil {
-		_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+		var curMsg *models.Message
+		if update.CallbackQuery.Message.Message != nil {
+			curMsg = update.CallbackQuery.Message.Message
+		}
+		_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 			ChatID:      chatID,
 			MessageID:   msgID,
 			ParseMode:   models.ParseModeHTML,
@@ -111,7 +119,11 @@ func (h *Handler) PromoCreateCallbackHandler(ctx context.Context, b *bot.Bot, up
 		return
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -149,7 +161,11 @@ func (h *Handler) PromoEnterCallbackHandler(ctx context.Context, b *bot.Bot, upd
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -201,7 +217,11 @@ func (h *Handler) ReferralStatsCallbackHandler(ctx context.Context, b *bot.Bot, 
 		{{Text: tm.GetText(langCode, "back_button"), CallbackData: CallbackReferral}},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -239,7 +259,11 @@ func (h *Handler) PromoCodesCallbackHandler(ctx context.Context, b *bot.Bot, upd
 		},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -329,7 +353,11 @@ func (h *Handler) PromoListCallbackHandler(ctx context.Context, b *bot.Bot, upda
 
 	kb = append(kb, []models.InlineKeyboardButton{{Text: tm.GetText(langCode, "back_button"), CallbackData: CallbackPromoCodes}})
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,
@@ -421,10 +449,14 @@ func (h *Handler) PromoDeleteConfirmationCallbackHandler(ctx context.Context, b 
 		kb := [][]models.InlineKeyboardButton{
 			{{Text: tm.GetText(langCode, "back_button"), CallbackData: CallbackPromoList}},
 		}
-		_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
-			ChatID:    chatID,
-			MessageID: msgID,
-			ParseMode: models.ParseModeHTML,
+		var curMsg *models.Message
+		if update.CallbackQuery.Message.Message != nil {
+			curMsg = update.CallbackQuery.Message.Message
+		}
+		_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
+			ChatID:      chatID,
+			MessageID:   msgID,
+			ParseMode:   models.ParseModeHTML,
 			Text:        tm.GetText(langCode, "promo_active_when_delete"),
 			ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
 		})
@@ -439,10 +471,14 @@ func (h *Handler) PromoDeleteConfirmationCallbackHandler(ctx context.Context, b 
 		{{Text: tm.GetText(langCode, "back_button"), CallbackData: CallbackPromoList}},
 	}
 
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
-		ChatID:    chatID,
-		MessageID: msgID,
-		ParseMode: models.ParseModeHTML,
+	var curMsg2 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg2 = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg2, &bot.EditMessageTextParams{
+		ChatID:      chatID,
+		MessageID:   msgID,
+		ParseMode:   models.ParseModeHTML,
 		Text:        tm.GetText(langCode, "promo_confirm_when_delete"),
 		ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb},
 	})

--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -115,7 +115,11 @@ func (h *Handler) StartCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 
-	_, err = b.EditMessageText(ctxWithTime, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctxWithTime, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		ParseMode:   models.ParseModeHTML,

--- a/internal/adapter/telegram/handler/trial.go
+++ b/internal/adapter/telegram/handler/trial.go
@@ -36,7 +36,11 @@ func (h *Handler) TrialCallbackHandler(ctx context.Context, b *bot.Bot, update *
 		return
 	}
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg, &bot.EditMessageTextParams{
 		ChatID:    chatID,
 		MessageID: msgID,
 		Text:      h.translation.GetText(langCode, "trial_text"),
@@ -79,7 +83,11 @@ func (h *Handler) ActivateTrialCallbackHandler(ctx context.Context, b *bot.Bot, 
 	}
 
 	langCode := update.CallbackQuery.From.LanguageCode
-	_, err = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	var curMsg2 *models.Message
+	if update.CallbackQuery.Message.Message != nil {
+		curMsg2 = update.CallbackQuery.Message.Message
+	}
+	_, err = SafeEditMessageText(ctx, b, curMsg2, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		Text:        h.translation.GetText(langCode, "trial_activated"),

--- a/internal/adapter/telegram/handler/utils.go
+++ b/internal/adapter/telegram/handler/utils.go
@@ -90,7 +90,7 @@ func (h *Handler) promptPromoMonths(ctx context.Context, b *bot.Bot, msg *models
 	}
 
 	bal := int(customer.Balance)
-	_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, _ = SafeEditMessageText(ctx, b, msg, &bot.EditMessageTextParams{
 		ChatID:    msg.Chat.ID,
 		MessageID: msg.ID,
 		ParseMode: models.ParseModeHTML,
@@ -113,7 +113,7 @@ func (h *Handler) promptPromoUses(ctx context.Context, b *bot.Bot, msg *models.M
 		kb = append(kb, []models.InlineKeyboardButton{{Text: label, CallbackData: fmt.Sprintf("%s?u=%d", CallbackPromoCreate, u)}})
 	}
 	kb = append(kb, []models.InlineKeyboardButton{{Text: h.translation.GetText(lang, "back_button"), CallbackData: CallbackReferral}})
-	_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+	_, _ = SafeEditMessageText(ctx, b, msg, &bot.EditMessageTextParams{
 		ChatID:      msg.Chat.ID,
 		MessageID:   msg.ID,
 		Text:        h.translation.GetText(lang, "promo_choose_uses"),


### PR DESCRIPTION
## Summary
- use `SafeEditMessageText` everywhere in handlers
- avoid noisy "message is not modified" errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68832979adc8832aa6b868ff53bf781e