### PR TITLE
Add error returns and list builders for sync service

### DIFF
--- a/internal/adapter/telegram/handler/sync.go
+++ b/internal/adapter/telegram/handler/sync.go
@@ -9,7 +9,9 @@ import (
 )
 
 func (h *Handler) SyncUsersCommandHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	h.syncService.Sync(ctx)
+	if err := h.syncService.Sync(ctx); err != nil {
+		slog.Error("Error syncing users", "err", err)
+	}
 	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: update.Message.Chat.ID,
 		Text:   "Users synced",

--- a/internal/service/sync/sync.go
+++ b/internal/service/sync/sync.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"remnawave-tg-shop-bot/internal/adapter/remnawave"
 	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
@@ -20,19 +21,20 @@ func NewSyncService(client *remnawave.Client, customerRepository custrepo.Reposi
 	}
 }
 
-func (s SyncService) Sync(ctx context.Context) {
+func (s SyncService) Sync(ctx context.Context) error {
 	slog.Info("Starting sync")
 	var telegramIDs []int64
 	telegramIDsSet := make(map[int64]int64)
 	var mappedUsers []domaincustomer.Customer
 	users, err := s.client.GetUsers(ctx)
 	if err != nil {
-		slog.Error("Error while getting users from remnawave")
-		return
+		slog.Error("Error while getting users from remnawave", "err", err)
+		return err
 	}
 	if users == nil || len(*users) == 0 {
-		slog.Error("No users found in remnawave")
-		return
+		err := fmt.Errorf("no users found in remnawave")
+		slog.Error(err.Error())
+		return err
 	}
 
 	for _, user := range *users {
@@ -57,46 +59,60 @@ func (s SyncService) Sync(ctx context.Context) {
 
 	existingCustomers, err := s.customerRepository.FindByTelegramIds(ctx, telegramIDs)
 	if err != nil {
-		slog.Error("Error while searching users by telegram ids")
-		return
+		slog.Error("Error while searching users by telegram ids", "err", err)
+		return err
 	}
 	existingMap := make(map[int64]domaincustomer.Customer)
 	for _, cust := range existingCustomers {
 		existingMap[cust.TelegramID] = cust
 	}
 
-	var toCreate []domaincustomer.Customer
-	var toUpdate []domaincustomer.Customer
-
-	for _, cust := range mappedUsers {
-		if _, found := existingMap[cust.TelegramID]; found {
-			cust.CreatedAt = time.Now()
-			toUpdate = append(toUpdate, cust)
-		} else {
-			toCreate = append(toCreate, cust)
-		}
-	}
+	toCreate := buildToCreate(mappedUsers, existingMap)
+	toUpdate := buildToUpdate(mappedUsers, existingMap)
 
 	err = s.customerRepository.DeleteByNotInTelegramIds(ctx, telegramIDs)
 	if err != nil {
-		slog.Error("Error while deleting users")
+		slog.Error("Error while deleting users", "err", err)
+		return err
 	}
 	slog.Info("Deleted clients which not exist in panel")
 
 	if len(toCreate) > 0 {
 		if err := s.customerRepository.CreateBatch(ctx, toCreate); err != nil {
-			slog.Error("Error while creating users")
-		} else {
-			slog.Info("Created clients", "count", len(toCreate))
+			slog.Error("Error while creating users", "err", err)
+			return err
 		}
+		slog.Info("Created clients", "count", len(toCreate))
 	}
 
 	if len(toUpdate) > 0 {
 		if err := s.customerRepository.UpdateBatch(ctx, toUpdate); err != nil {
-			slog.Error("Error while updating users")
-		} else {
-			slog.Info("Updated clients", "count", len(toUpdate))
+			slog.Error("Error while updating users", "err", err)
+			return err
 		}
+		slog.Info("Updated clients", "count", len(toUpdate))
 	}
 	slog.Info("Synchronization completed")
+	return nil
+}
+
+func buildToCreate(mapped []domaincustomer.Customer, existing map[int64]domaincustomer.Customer) []domaincustomer.Customer {
+	var res []domaincustomer.Customer
+	for _, cust := range mapped {
+		if _, found := existing[cust.TelegramID]; !found {
+			res = append(res, cust)
+		}
+	}
+	return res
+}
+
+func buildToUpdate(mapped []domaincustomer.Customer, existing map[int64]domaincustomer.Customer) []domaincustomer.Customer {
+	var res []domaincustomer.Customer
+	for _, cust := range mapped {
+		if _, found := existing[cust.TelegramID]; found {
+			cust.CreatedAt = time.Now()
+			res = append(res, cust)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
## Summary
- build `toCreate` and `toUpdate` via helper functions
- return errors from `Sync` instead of only logging
- handle returned error in telegram handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68832b497c10832a8396c2556d7c7a56