### PR TITLE
Add config validation helpers

### DIFF
--- a/tests/config_validation_test.go
+++ b/tests/config_validation_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"testing"
+
+	"remnawave-tg-shop-bot/internal/pkg/config"
+)
+
+func TestInitConfigInvalidURL(t *testing.T) {
+	SetTestEnv(t)
+	t.Setenv("REMNAWAVE_URL", "://bad_url")
+	if err := config.InitConfig(); err == nil {
+		t.Fatal("expected error for invalid url")
+	}
+}
+
+func TestInitConfigInvalidToken(t *testing.T) {
+	SetTestEnv(t)
+	t.Setenv("TELEGRAM_TOKEN", "bad token")
+	if err := config.InitConfig(); err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}


### PR DESCRIPTION
## Summary
- validate URLs and tokens in config
- return detailed errors from `InitConfig`
- test validation logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68832edc242c832a97b2ff9e0e7db90d