### PR TITLE
Add staticcheck and Dockerfile lint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,14 @@ jobs:
         with:
           version: v2.1
           args: --config=.golangci.yml --timeout=5m
+      - name: Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ./Dockerfile
       - name: Vet
         run: go vet ./...
+      - name: Staticcheck
+        uses: dominikh/staticcheck-action@v1
       - name: Test build
         run: go build ./...
       - name: Unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 FROM deps AS build
 COPY . .
-RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
+RUN apk add --no-cache \
+    ca-certificates=20250619-r0 \
+    tzdata=2025b-r0 \
+    && update-ca-certificates
 ARG TARGETOS TARGETARCH VERSION
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
## Summary
- run hadolint on the Dockerfile
- run staticcheck alongside go vet
- pin apk package versions in Dockerfile to satisfy DL3018

## Testing
- `hadolint Dockerfile`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `go build ./...`
- `go test ./tests -cover -coverpkg=./...`


------
https://chatgpt.com/codex/tasks/task_e_6883330000ec832aae6ac70c9d2a7802

## Сводка от Sourcery

Добавить линтование и статический анализ Dockerfile в рабочие процессы CI, а также закрепить версии пакетов apk в Dockerfile.

Улучшения:
- Закрепить версии пакетов apk в Dockerfile для соответствия DL3018

CI:
- Запустить hadolint для Dockerfile
- Запустить staticcheck вместе с go vet

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Dockerfile linting and static analysis to CI workflows and pin apk package versions in the Dockerfile

Enhancements:
- Pin apk package versions in Dockerfile to satisfy DL3018

CI:
- Run hadolint on the Dockerfile
- Run staticcheck alongside go vet

</details>