### PR TITLE
Fix WebApp link flag typo

### DIFF
--- a/internal/adapter/telegram/handler/connect.go
+++ b/internal/adapter/telegram/handler/connect.go
@@ -69,7 +69,7 @@ func (h *Handler) ConnectCallbackHandler(ctx context.Context, b *bot.Bot, update
 	langCode := update.CallbackQuery.From.LanguageCode
 
 	var markup [][]models.InlineKeyboardButton
-	if config.IsWepAppLinkEnabled() {
+	if config.IsWebAppLinkEnabled() {
 		if customer.SubscriptionLink != nil && customer.ExpireAt.After(time.Now()) {
 			markup = append(markup, []models.InlineKeyboardButton{{Text: h.translation.GetText(langCode, "connect_button"),
 				WebApp: &models.WebAppInfo{
@@ -117,7 +117,7 @@ func buildConnectText(customer *domaincustomer.Customer, langCode string) string
 			info.WriteString(fmt.Sprintf(subscriptionActiveText, formattedDate))
 
 			if customer.SubscriptionLink != nil && *customer.SubscriptionLink != "" {
-				if config.IsWepAppLinkEnabled() {
+				if config.IsWebAppLinkEnabled() {
 				} else {
 					subscriptionLinkText := tm.GetText(langCode, "subscription_link")
 					info.WriteString(fmt.Sprintf(subscriptionLinkText, *customer.SubscriptionLink))

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -218,7 +218,7 @@ func GetHealthCheckPort() int {
 	return conf.healthCheckPort
 }
 
-func IsWepAppLinkEnabled() bool {
+func IsWebAppLinkEnabled() bool {
 	return conf.isWebAppLinkEnabled
 }
 


### PR DESCRIPTION
## Summary
- rename `IsWepAppLinkEnabled` to `IsWebAppLinkEnabled`
- update call sites

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68834894ced8832aa7285ad083e0e582