### PR TITLE
Integrate Tribute MiniApp

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,7 +57,7 @@ CHANNEL_URL="https://t.me/examplechannel"
 # Example: 773db654-a8b2-413a-a50b-75c3536238fd,bc979bdd-f1fa-4d94-8a51-38a0f518a2a2
 INBOUND_UUIDS=
 # Tribute payment integration
-TRIBUTE_WEBHOOK_URL=/tribute/webhook
+TRIBUTE_WEBHOOK_URL=/tribute
 TRIBUTE_API_KEY=changeme
 TRIBUTE_PAYMENT_URL=https://t.me/example_bot
 

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/go-telegram/bot v1.15.0
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/joho/godotenv v1.5.1
-	github.com/pashagolub/pgxmock v1.3.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/robfig/cron/v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -80,7 +82,6 @@ github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsU
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8/2JY=
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
-github.com/jackc/pgconn v1.10.0/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgconn v1.14.3 h1:bVoTr12EGANZz66nZPkMInAV/KHD2TxH9npjXXgiB3w=
 github.com/jackc/pgconn v1.14.3/go.mod h1:RZbme4uasqzybK2RK5c65VsHxoyaml09lx3tXOcO/VM=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
@@ -99,7 +100,6 @@ github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod 
 github.com/jackc/pgproto3/v2 v2.0.0-rc3/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
-github.com/jackc/pgproto3/v2 v2.0.7/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.3.3 h1:1HLSx5H+tXR9pW3in3zaztoEwQYRC9SQaYUHjTSUOag=
 github.com/jackc/pgproto3/v2 v2.3.3/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
@@ -111,7 +111,6 @@ github.com/jackc/pgtype v0.0.0-20190421001408-4ed0de4755e0/go.mod h1:hdSHsc1V01C
 github.com/jackc/pgtype v0.0.0-20190824184912-ab885b375b90/go.mod h1:KcahbBH1nCMSo2DXpzsoWOAfFkdEtEJpPbVLq8eE+mc=
 github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrUS8lot6TQqcg7mtthZ9T0EoIBFiJcmcyw=
 github.com/jackc/pgtype v1.8.1-0.20210724151600-32e20a603178/go.mod h1:C516IlIV9NKqfsMCXTdChteoXmwgUceqaLfjg2e3NlM=
-github.com/jackc/pgtype v1.8.1/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgtype v1.14.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgtype v1.14.4 h1:fKuNiCumbKTAIxQwXfB/nsrnkEI6bPJrrSiMKgbJ2j8=
 github.com/jackc/pgtype v1.14.4/go.mod h1:aKeozOde08iifGosdJpz9MBZonJOUJxqNpPBcMJTlVA=
@@ -119,7 +118,6 @@ github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
-github.com/jackc/pgx/v4 v4.13.0/go.mod h1:9P4X524sErlaxj0XSGZk7s+LD0eOyu1ZDUrrpznYDF0=
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/pgx/v4 v4.18.3 h1:dE2/TrEsGX3RBprb3qryqSV9Y60iZN1C6i8IrmW9/BA=
 github.com/jackc/pgx/v4 v4.18.3/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
@@ -172,9 +170,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/pashagolub/pgxmock v1.3.0 h1:xtQ0+MSxoCT/b6N+oLo8KCtm/QilF4wxaVMyPBKxSzU=
-github.com/pashagolub/pgxmock v1.3.0/go.mod h1:Ktp8tF8SkFOibmga06ubwrpr9ZL6zAa1qdo9oq2NG60=
-github.com/pashagolub/pgxstruct v0.0.0-20210217101842-40d357eec200/go.mod h1:fOTLLi1PtVUDXx28olVT/D2UMFCmBEYpnY5QIzghmDc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/adapter/payment/tribute/client.go
+++ b/internal/adapter/payment/tribute/client.go
@@ -1,0 +1,68 @@
+package tribute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Option func(*APIClient)
+
+func WithHTTPClient(c *http.Client) Option { return func(cl *APIClient) { cl.httpClient = c } }
+
+func WithBaseURL(url string) Option { return func(cl *APIClient) { cl.baseURL = url } }
+
+// OrderDTO represents order info returned by Tribute.
+type OrderDTO struct {
+	ID         int    `json:"id"`
+	Amount     int64  `json:"amount"`
+	Currency   string `json:"currency"`
+	TelegramID int64  `json:"telegram_id"`
+}
+
+type APIClient struct {
+	httpClient *http.Client
+	apiKey     string
+	baseURL    string
+}
+
+const defaultBaseURL = "https://tribute.tg/api/v1"
+
+func New(apiKey string, opts ...Option) *APIClient {
+	c := &APIClient{apiKey: apiKey, httpClient: http.DefaultClient, baseURL: defaultBaseURL}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+func (c *APIClient) ListOrders(ctx context.Context, limit, lastID int) ([]OrderDTO, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/orders", nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if lastID > 0 {
+		q.Set("last_id", fmt.Sprintf("%d", lastID))
+	}
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var out []OrderDTO
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/adapter/payment/tribute/client_test.go
+++ b/internal/adapter/payment/tribute/client_test.go
@@ -1,0 +1,38 @@
+package tribute
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientListOrders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Api-Key") != "k" {
+			t.Fatalf("missing header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":1}]`))
+	}))
+	defer ts.Close()
+	c := New("k", WithBaseURL(ts.URL), WithHTTPClient(ts.Client()))
+	orders, err := c.ListOrders(context.Background(), 0, 0)
+	if err != nil || len(orders) != 1 || orders[0].ID != 1 {
+		t.Fatalf("unexpected result %v %v", orders, err)
+	}
+}
+
+func TestClientNetworkError(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("boom") })
+	hc := &http.Client{Transport: rt}
+	c := New("k", WithHTTPClient(hc), WithBaseURL("http://example"))
+	if _, err := c.ListOrders(context.Background(), 0, 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/adapter/payment/tribute/webhook.go
+++ b/internal/adapter/payment/tribute/webhook.go
@@ -1,0 +1,77 @@
+package tribute
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"remnawave-tg-shop-bot/internal/service/customer"
+)
+
+// Handler processes Tribute webhooks.
+type Handler struct {
+	apiKey      string
+	svcCustomer customer.Service
+	dedup       *lru.Cache[string, struct{}]
+}
+
+// NewHandler constructs Handler with LRU deduplication cache.
+func NewHandler(apiKey string, svc customer.Service) *Handler {
+	cache, _ := lru.New[string, struct{}](1000)
+	return &Handler{apiKey: apiKey, svcCustomer: svc, dedup: cache}
+}
+
+type webhookBody struct {
+	Event      string `json:"event"`
+	Amount     int64  `json:"amount"`
+	Currency   string `json:"currency"`
+	TelegramID int64  `json:"telegram_id"`
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	_ = r.Body.Close()
+
+	sig := r.Header.Get("trbt-signature")
+	mac := hmac.New(sha256.New, []byte(h.apiKey))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(sig)) {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	sum := sha256.Sum256(body)
+	key := hex.EncodeToString(sum[:])
+	if h.dedup.Contains(key) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	h.dedup.Add(key, struct{}{})
+
+	var wb webhookBody
+	if err := json.Unmarshal(body, &wb); err != nil {
+		slog.Error("webhook: unmarshal", "err", err)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	switch wb.Event {
+	case "new_subscription", "recurrent_donation", "subscription.payment":
+		if err := h.svcCustomer.AddBalance(r.Context(), wb.TelegramID, wb.Amount); err != nil {
+			slog.Error("add balance", "err", err)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/adapter/payment/tribute/webhook_test.go
+++ b/internal/adapter/payment/tribute/webhook_test.go
@@ -1,0 +1,47 @@
+package tribute
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type stubService struct{ calls int }
+
+func (s *stubService) AddBalance(ctx context.Context, tg int64, amt int64) error {
+	s.calls++
+	return nil
+}
+
+func TestWebhookHandler(t *testing.T) {
+	svc := &stubService{}
+	h := NewHandler("key", svc)
+	body := []byte(`{"event":"new_subscription","amount":10,"currency":"RUB","telegram_id":1}`)
+	mac := hmac.New(sha256.New, []byte("key"))
+	mac.Write(body)
+	sig := hex.EncodeToString(mac.Sum(nil))
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	r.Header.Set("trbt-signature", sig)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK || svc.calls != 1 {
+		t.Fatalf("code %d calls %d", w.Code, svc.calls)
+	}
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if svc.calls != 1 {
+		t.Fatalf("duplicate call")
+	}
+	r = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	r.Header.Set("trbt-signature", "bad")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden || svc.calls != 1 {
+		t.Fatalf("expected 403 and single call")
+	}
+}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,15 @@
+package config
+
+import "testing"
+
+func TestValidatePath(t *testing.T) {
+	if err := ValidatePath("/tribute", "TRIBUTE_WEBHOOK_URL"); err != nil {
+		t.Fatalf("valid path: %v", err)
+	}
+	if err := ValidatePath("tribute", "TRIBUTE_WEBHOOK_URL"); err == nil || err.Error() != "TRIBUTE_WEBHOOK_URL must start with \"/\"" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidatePath("", "TRIBUTE_WEBHOOK_URL"); err == nil || err.Error() != "TRIBUTE_WEBHOOK_URL is required" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/service/customer/balance.go
+++ b/internal/service/customer/balance.go
@@ -1,0 +1,31 @@
+package customer
+
+import (
+	"context"
+	"fmt"
+)
+
+type Service interface {
+	AddBalance(ctx context.Context, telegramID int64, amountRUB int64) error
+}
+
+// BalanceService implements Service.
+type BalanceService struct {
+	repo Repository
+}
+
+func NewService(repo Repository) *BalanceService {
+	return &BalanceService{repo: repo}
+}
+
+func (s *BalanceService) AddBalance(ctx context.Context, telegramID int64, amountRUB int64) error {
+	c, err := s.repo.FindByTelegramId(ctx, telegramID)
+	if err != nil {
+		return err
+	}
+	if c == nil {
+		return fmt.Errorf("customer %d not found", telegramID)
+	}
+	newBal := c.Balance + float64(amountRUB)
+	return s.repo.UpdateFields(ctx, c.ID, map[string]interface{}{"balance": newBal})
+}

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ The application requires the following environment variables to be set:
 | `TRIAL_TRAFFIC_LIMIT`    | Maximum allowed traffic in gb for trial subscriptions                                                                                        |     
 | `TRIAL_DAYS`             | Number of days for trial subscriptions. if 0 = disabled.                                                                                     |
 | `INBOUND_UUIDS`          | Comma-separated list of inbound UUIDs to assign to users (e.g., "773db654-a8b2-413a-a50b-75c3536238fd,bc979bdd-f1fa-4d94-8a51-38a0f518a2a2") |
-| `TRIBUTE_WEBHOOK_URL`    | Path for webhook handler. Example: /example (https://www.uuidgenerator.net/version4)                                                         |
+| `TRIBUTE_WEBHOOK_URL`    | Path for webhook handler. Example: /tribute |
 | `TRIBUTE_API_KEY`        | Api key, which can be obtained via settings in Tribute app.                                                                                  |
 | `TRIBUTE_PAYMENT_URL`    | You payment url for Tribute. (Subscription telegram link)                                                                                    |
 
@@ -184,10 +184,10 @@ The bot supports subscription management via the Tribute service. When a user cl
   * Obtain the subscription link (Subscription -> Links -> Telegram Link).
 
 2. Configure environment variables in `.env`
-    * Set the webhook path (e.g., `/tribute/webhook`):
+    * Set the webhook path (e.g., `/tribute`):
 
     ```
-    TRIBUTE_WEBHOOK_URL=/tribute/webhook
+    TRIBUTE_WEBHOOK_URL=/tribute
     ```
 
     * Set the API key from your Tribute settings:

--- a/tests/testutils.go
+++ b/tests/testutils.go
@@ -31,6 +31,9 @@ func SetTestEnv(t *testing.T) {
 	t.Setenv("REFERRAL_BONUS", "0")
 	t.Setenv("CRYPTO_PAY_ENABLED", "false")
 	t.Setenv("TELEGRAM_STARS_ENABLED", "false")
+	t.Setenv("TRIBUTE_WEBHOOK_URL", "/tribute")
+	t.Setenv("TRIBUTE_API_KEY", "k")
+	t.Setenv("TRIBUTE_PAYMENT_URL", "http://t.me/pay")
 }
 
 // MustGetEnvForTest fails the test if the environment variable is not set.


### PR DESCRIPTION
## Summary
- validate Tribute webhook path via `ValidatePath`
- add REST client and webhook handler for Tribute
- implement balance service
- expose Tribute webhook in bot HTTP server
- document Tribute setup
- sample env updates

## Testing
- `golangci-lint run --config=.golangci.yml`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688347f11204832aa398f11486346ebf