### PR TITLE
Improve sell plan message

### DIFF
--- a/internal/adapter/telegram/handler/payment_handlers.go
+++ b/internal/adapter/telegram/handler/payment_handlers.go
@@ -103,7 +103,23 @@ func (h *Handler) SellCallbackHandler(ctx context.Context, b *bot.Bot, update *m
 		{Text: h.translation.GetText(langCode, "back_button"), CallbackData: CallbackBuy},
 	})
 
-	text := fmt.Sprintf(h.translation.GetText(langCode, "selected_months"), month)
+	customer, _ := h.customerRepository.FindByTelegramId(ctx, chatID)
+	bal := 0
+	if customer != nil {
+		bal = int(customer.Balance)
+	}
+
+	var line string
+	switch month {
+	case "1":
+		line = fmt.Sprintf(h.translation.GetText(langCode, "plan_line_1"), h.translation.GetText(langCode, "month_1"), config.Price1())
+	case "3":
+		line = fmt.Sprintf(h.translation.GetText(langCode, "plan_line_3"), h.translation.GetText(langCode, "month_3"), config.Price3())
+	case "6":
+		line = fmt.Sprintf(h.translation.GetText(langCode, "plan_line_6"), h.translation.GetText(langCode, "month_6"), config.Price6())
+	}
+
+	text := fmt.Sprintf(h.translation.GetText(langCode, "selected_plan_text"), bal, line)
 
 	var curMsg *models.Message
 	if update.CallbackQuery.Message.Message != nil {

--- a/tests/handler_payment_handlers_test.go
+++ b/tests/handler_payment_handlers_test.go
@@ -3,8 +3,11 @@ package tests
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,8 +15,10 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	handlerpkg "remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
 	domainpurchase "remnawave-tg-shop-bot/internal/domain/purchase"
 	"remnawave-tg-shop-bot/internal/pkg/cache"
+	"remnawave-tg-shop-bot/internal/pkg/config"
 	"remnawave-tg-shop-bot/internal/pkg/translation"
 	"remnawave-tg-shop-bot/internal/service/payment"
 )
@@ -64,6 +69,19 @@ func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+type captureClient struct {
+	body        []byte
+	contentType string
+}
+
+func (c *captureClient) Do(req *http.Request) (*http.Response, error) {
+	c.contentType = req.Header.Get("Content-Type")
+	c.body, _ = io.ReadAll(req.Body)
+	resp := &http.Response{StatusCode: http.StatusOK}
+	resp.Body = io.NopCloser(bytes.NewReader([]byte(`{"ok":true,"result":{"message_id":1}}`)))
+	return resp, nil
+}
+
 func TestPaymentCallbackHandler_ContextPropagation(t *testing.T) {
 	custRepo := &StubCustomerRepo{}
 	purchRepo := &stubPurchaseRepo{}
@@ -99,5 +117,81 @@ func TestPaymentCallbackHandler_ContextPropagation(t *testing.T) {
 	}
 	if messenger.ctx.Value(CtxKey{}) != "v" {
 		t.Errorf("context not propagated to messenger")
+	}
+}
+
+func parseText(t *testing.T, c *captureClient) string {
+	t.Helper()
+	boundary := strings.TrimPrefix(c.contentType, "multipart/form-data; boundary=")
+	r := multipart.NewReader(bytes.NewReader(c.body), boundary)
+	for {
+		p, err := r.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		if p.FormName() == "text" {
+			b, _ := io.ReadAll(p)
+			return string(b)
+		}
+	}
+	t.Fatalf("text field not found")
+	return ""
+}
+
+func TestSellCallbackHandler_Text(t *testing.T) {
+	SetTestEnv(t)
+	t.Setenv("PRICE_1", "10")
+	t.Setenv("PRICE_3", "30")
+	t.Setenv("PRICE_6", "60")
+
+	trans := translation.GetInstance()
+	if err := trans.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+
+	if err := config.InitConfig(); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+
+	repo := &StubCustomerRepo{CustomerByTelegramID: &domaincustomer.Customer{TelegramID: 1, Balance: 100}}
+	h := handlerpkg.NewHandler(nil, nil, trans, repo, nil, nil, nil, nil, nil)
+
+	cases := []struct {
+		month int
+	}{{1}, {3}, {6}}
+
+	for _, tc := range cases {
+		client := &captureClient{}
+		b, err := bot.New("token", bot.WithHTTPClient(time.Second, client), bot.WithSkipGetMe())
+		if err != nil {
+			t.Fatalf("bot init: %v", err)
+		}
+		upd := &models.Update{
+			CallbackQuery: &models.CallbackQuery{
+				Data:    fmt.Sprintf("sell?month=%d", tc.month),
+				From:    models.User{ID: 1, LanguageCode: "ru"},
+				Message: models.MaybeInaccessibleMessage{Message: &models.Message{ID: 1, Chat: models.Chat{ID: 1}}},
+			},
+		}
+		h.SellCallbackHandler(context.Background(), b, upd)
+		got := parseText(t, client)
+
+		var line string
+		switch tc.month {
+		case 1:
+			line = fmt.Sprintf(trans.GetText("ru", "plan_line_1"), trans.GetText("ru", "month_1"), config.Price1())
+		case 3:
+			line = fmt.Sprintf(trans.GetText("ru", "plan_line_3"), trans.GetText("ru", "month_3"), config.Price3())
+		case 6:
+			line = fmt.Sprintf(trans.GetText("ru", "plan_line_6"), trans.GetText("ru", "month_6"), config.Price6())
+		}
+		expect := fmt.Sprintf(trans.GetText("ru", "selected_plan_text"), 100, line)
+
+		if got != expect {
+			t.Errorf("month %d text mismatch\nexpected: %q\n got: %q", tc.month, expect, got)
+		}
 	}
 }

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -3,7 +3,10 @@ back_button: 🔙 Back
 month_1: 1 month
 month_3: 3 months
 month_6: 6 months
-selected_months: "You selected %s months subscription"
+plan_line_1: "✨ %s — %d rubles"
+plan_line_3: "❤️‍🔥 %s — %d rubles"
+plan_line_6: "🔥 %s — %d rubles"
+selected_plan_text: "📌 Choose subscription period 📌\n\n💎 Current balance: %d rubles\n\n%s\n\n⭐️ Payment will be deducted from your personal account."
 crypto_button: ₿ Cryptocurrency
 pay_button: 💸 Pay
 subscription_active: 'Your subscription is valid until: %s'

--- a/translations/ru.yml
+++ b/translations/ru.yml
@@ -3,7 +3,10 @@ back_button: 🔙 Назад
 month_1: 1 месяц
 month_3: 3 месяца
 month_6: 6 месяцев
-selected_months: "Вы выбрали %s месяцев подписки"
+plan_line_1: "✨ %s — %d рублей"
+plan_line_3: "❤️‍🔥 %s — %d рублей"
+plan_line_6: "🔥 %s — %d рублей"
+selected_plan_text: "📌 Выберите срок подписки на сервис 📌\n\n💎 Текущий баланс: %d рублей\n\n%s\n\n⭐️ Оплата будет списана с вашего личного счёта в Личном Кабинете."
 crypto_button: ₿ Криптовалютой
 pay_button: 💸 Оплатить
 subscription_active: 'Ваша подписка действует до: %s'


### PR DESCRIPTION
## Summary
- enhance sell menu text building
- add translation keys for single-plan message
- test balance sell message for all plans

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68834f89bc94832aa9010b4063fa9baf