### PR TITLE
Fix linter warnings and update workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1
+          args: --config=.golangci.yml --timeout=5m
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	"remnawave-tg-shop-bot/internal/pkg/config"
-	"remnawave-tg-shop-bot/internal/pkg/contextkey"
 	"remnawave-tg-shop-bot/internal/pkg/translation"
 	"remnawave-tg-shop-bot/internal/service/payment"
 	menu "remnawave-tg-shop-bot/internal/ui/menu"


### PR DESCRIPTION
## Summary
- remove unused `contextkey` import from referral handler
- run golangci-lint in docker build workflow before building

## Testing
- `go build ./...`
- `golangci-lint run --config=.golangci.yml`
- `docker build .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841b1485b8832aaca52dc8408e4462