### PR TITLE
Refactor promo/ref menu

### DIFF
--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-telegram/bot/models"
 
 	"remnawave-tg-shop-bot/internal/pkg/config"
+	"remnawave-tg-shop-bot/internal/pkg/contextkey"
 	"remnawave-tg-shop-bot/internal/pkg/translation"
 	"remnawave-tg-shop-bot/internal/service/payment"
 	menu "remnawave-tg-shop-bot/internal/ui/menu"
@@ -31,7 +32,8 @@ func (h *Handler) ReferralCallbackHandler(ctx context.Context, b *bot.Bot, updat
 		return
 	}
 
-	kb := menu.BuildPromoRefMenu(langCode)
+	admin := contextkey.IsAdminFromContext(ctx)
+	kb := menu.BuildPromoRefMain(langCode, admin)
 
 	var curMsg *models.Message
 	if update.CallbackQuery.Message.Message != nil {

--- a/internal/ui/menu/keyboard.go
+++ b/internal/ui/menu/keyboard.go
@@ -76,14 +76,25 @@ func BuildLKMenu(lang string, c *domaincustomer.Customer, isAdmin bool) [][]mode
 }
 
 // BuildPromoRefMenu builds promo/referral menu for regular users.
-func BuildPromoRefMenu(lang string) [][]models.InlineKeyboardButton {
+// BuildPromoRefMain builds promo/referral menu for regular users.
+// If isAdmin is true the admin promo menu button is also added.
+func BuildPromoRefMain(lang string, isAdmin bool) [][]models.InlineKeyboardButton {
 	tm := translation.GetInstance()
-	return [][]models.InlineKeyboardButton{
+	kb := [][]models.InlineKeyboardButton{
 		{{Text: tm.GetText(lang, "activate_promocode_button"), CallbackData: CallbackPromoUserActivate}},
 		{{Text: tm.GetText(lang, "referral_system_button"), CallbackData: CallbackRefUserStats}},
 		{{Text: tm.GetText(lang, "personal_promocodes_button"), CallbackData: CallbackPromoUserPersonal}},
-		{{Text: tm.GetText(lang, "back_to_account_button"), CallbackData: "start"}},
 	}
+	if isAdmin {
+		kb = append(kb, []models.InlineKeyboardButton{{Text: tm.GetText(lang, "admin_panel_button"), CallbackData: CallbackPromoAdminMenu}})
+	}
+	kb = append(kb, []models.InlineKeyboardButton{{Text: tm.GetText(lang, "back_to_account_button"), CallbackData: "start"}})
+	return kb
+}
+
+// BuildPromoRefMenu is kept for backward compatibility.
+func BuildPromoRefMenu(lang string) [][]models.InlineKeyboardButton {
+	return BuildPromoRefMain(lang, false)
 }
 
 // BuildAdminPromoMenu returns root admin promo menu keyboard.

--- a/internal/ui/menu/keyboard_test.go
+++ b/internal/ui/menu/keyboard_test.go
@@ -35,17 +35,30 @@ func TestBuildLKMenu_AdminButton(t *testing.T) {
 	}
 }
 
-func TestBuildPromoRefMenu(t *testing.T) {
+func TestBuildPromoRefMain(t *testing.T) {
 	tm := translation.GetInstance()
 	if err := tm.InitDefaultTranslations(); err != nil {
 		t.Fatalf("init translations: %v", err)
 	}
-	kb := BuildPromoRefMenu("ru")
+	kb := BuildPromoRefMain("ru", false)
 	for _, row := range kb {
 		for _, b := range row {
 			if b.CallbackData == CallbackPromoAdminMenu || b.Text == tm.GetText("ru", "faq_button") {
 				t.Fatalf("unexpected button %v", b)
 			}
 		}
+	}
+	// ensure admin button is present when requested
+	kb = BuildPromoRefMain("ru", true)
+	found := false
+	for _, row := range kb {
+		for _, b := range row {
+			if b.CallbackData == CallbackPromoAdminMenu {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("admin button missing")
 	}
 }


### PR DESCRIPTION
## Summary
- add `BuildPromoRefMain` with optional admin button
- adapt ReferralCallbackHandler to respect admin context
- update unit tests

FSM remains unchanged; new callbacks reuse existing ones.

## Testing
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_68841c514198832a8570ba363afccd00