### PR TITLE
Implement freeze/unfreeze/delete promo service

### DIFF
--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -210,20 +210,20 @@ func (h *Handler) PromoMyListCallbackHandler(ctx context.Context, b *bot.Bot, up
 }
 
 func (h *Handler) PromoMyFreezeCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyFreeze+":")
-	id, _ := strconv.ParseInt(idStr, 10, 64)
-	if err := h.promocodeRepository.UpdateStatus(ctx, id, false); err != nil {
-		slog.Error("freeze promo", "err", err)
-	}
+       idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyFreeze+":")
+       id, _ := strconv.ParseInt(idStr, 10, 64)
+       if err := h.promotionService.Freeze(ctx, id); err != nil {
+               slog.Error("freeze promo", "err", err)
+       }
 	h.PromoMyListCallbackHandler(ctx, b, update)
 }
 
 func (h *Handler) PromoMyUnfreezeCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyUnfreeze+":")
-	id, _ := strconv.ParseInt(idStr, 10, 64)
-	if err := h.promocodeRepository.UpdateStatus(ctx, id, true); err != nil {
-		slog.Error("unfreeze promo", "err", err)
-	}
+       idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyUnfreeze+":")
+       id, _ := strconv.ParseInt(idStr, 10, 64)
+       if err := h.promotionService.Unfreeze(ctx, id); err != nil {
+               slog.Error("unfreeze promo", "err", err)
+       }
 	h.PromoMyListCallbackHandler(ctx, b, update)
 }
 
@@ -257,11 +257,11 @@ func (h *Handler) PromoMyDeleteCallbackHandler(ctx context.Context, b *bot.Bot, 
 }
 
 func (h *Handler) PromoMyDeleteConfirmCallbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyDeleteConfirm+":")
-	id, _ := strconv.ParseInt(idStr, 10, 64)
-	if err := h.promocodeRepository.UpdateDeleteStatus(ctx, id, true); err != nil {
-		slog.Error("delete promo", "err", err)
-	}
+       idStr := strings.TrimPrefix(update.CallbackQuery.Data, menu.CallbackPromoMyDeleteConfirm+":")
+       id, _ := strconv.ParseInt(idStr, 10, 64)
+       if err := h.promotionService.Delete(ctx, id); err != nil {
+               slog.Error("delete promo", "err", err)
+       }
 	h.PromoMyListCallbackHandler(ctx, b, update)
 }
 

--- a/internal/service/promotion/repository.go
+++ b/internal/service/promotion/repository.go
@@ -9,4 +9,6 @@ import (
 // Repository provides persistence for promocodes.
 type Repository interface {
 	Create(ctx context.Context, promo *pg.Promocode) (*pg.Promocode, error)
+	UpdateStatus(ctx context.Context, id int64, active bool) error
+	UpdateDeleteStatus(ctx context.Context, id int64, deleted bool) error
 }

--- a/internal/service/promotion/service.go
+++ b/internal/service/promotion/service.go
@@ -13,6 +13,9 @@ const codeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 type Creator interface {
 	CreateSubscription(ctx context.Context, code string, days, limit int, createdBy int64) (string, error)
 	CreateBalance(ctx context.Context, amount, limit int, createdBy int64) (string, error)
+	Freeze(ctx context.Context, id int64) error
+	Unfreeze(ctx context.Context, id int64) error
+	Delete(ctx context.Context, id int64) error
 }
 
 type Service struct {
@@ -66,6 +69,21 @@ func (s *Service) CreateBalance(ctx context.Context, amount, limit int, createdB
 		return "", err
 	}
 	return code, nil
+}
+
+// Freeze sets promocode status to inactive.
+func (s *Service) Freeze(ctx context.Context, id int64) error {
+	return s.repo.UpdateStatus(ctx, id, false)
+}
+
+// Unfreeze sets promocode status to active.
+func (s *Service) Unfreeze(ctx context.Context, id int64) error {
+	return s.repo.UpdateStatus(ctx, id, true)
+}
+
+// Delete marks promocode as deleted.
+func (s *Service) Delete(ctx context.Context, id int64) error {
+	return s.repo.UpdateDeleteStatus(ctx, id, true)
 }
 
 func generateCode() (string, error) {

--- a/tests/admin_promo_handler_test.go
+++ b/tests/admin_promo_handler_test.go
@@ -41,6 +41,10 @@ func (s *promoServiceStub) CreateBalance(ctx context.Context, amount, limit int,
 	return "CODE", nil
 }
 
+func (s *promoServiceStub) Freeze(ctx context.Context, id int64) error   { return nil }
+func (s *promoServiceStub) Unfreeze(ctx context.Context, id int64) error { return nil }
+func (s *promoServiceStub) Delete(ctx context.Context, id int64) error   { return nil }
+
 type stubHTTP struct{ body string }
 
 func (h *stubHTTP) Do(r *http.Request) (*http.Response, error) {

--- a/tests/promotion_service_test.go
+++ b/tests/promotion_service_test.go
@@ -9,17 +9,39 @@ import (
 	"remnawave-tg-shop-bot/internal/service/promotion"
 )
 
-type stubPromoRepo struct{ store map[string]*pg.Promocode }
+type stubPromoRepo struct {
+	store  map[int64]*pg.Promocode
+	byCode map[string]int64
+	nextID int64
+}
 
 func (s *stubPromoRepo) Create(ctx context.Context, p *pg.Promocode) (*pg.Promocode, error) {
 	if s.store == nil {
-		s.store = make(map[string]*pg.Promocode)
+		s.store = make(map[int64]*pg.Promocode)
+		s.byCode = make(map[string]int64)
 	}
-	if _, ok := s.store[p.Code]; ok {
+	if _, ok := s.byCode[p.Code]; ok {
 		return nil, fmt.Errorf("duplicate")
 	}
-	s.store[p.Code] = p
+	s.nextID++
+	p.ID = s.nextID
+	s.store[p.ID] = p
+	s.byCode[p.Code] = p.ID
 	return p, nil
+}
+
+func (s *stubPromoRepo) UpdateStatus(ctx context.Context, id int64, active bool) error {
+	if p, ok := s.store[id]; ok {
+		p.Active = active
+	}
+	return nil
+}
+
+func (s *stubPromoRepo) UpdateDeleteStatus(ctx context.Context, id int64, deleted bool) error {
+	if p, ok := s.store[id]; ok {
+		p.Deleted = deleted
+	}
+	return nil
 }
 
 func TestCreateBalanceCodeUnique(t *testing.T) {
@@ -49,5 +71,33 @@ func TestCreateSubscriptionDuplicate(t *testing.T) {
 	}
 	if _, err := svc.CreateSubscription(context.Background(), "CODE", 30, 1, 1); err == nil {
 		t.Fatal("expected error for duplicate code")
+	}
+}
+
+func TestFreezeUnfreezeDelete(t *testing.T) {
+	repo := &stubPromoRepo{}
+	svc := promotion.NewService(repo)
+	code, err := svc.CreateBalance(context.Background(), 10, 1, 1)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	id := repo.byCode[code]
+	if err := svc.Freeze(context.Background(), id); err != nil {
+		t.Fatalf("freeze: %v", err)
+	}
+	if repo.store[id].Active {
+		t.Fatal("not frozen")
+	}
+	if err := svc.Unfreeze(context.Background(), id); err != nil {
+		t.Fatalf("unfreeze: %v", err)
+	}
+	if !repo.store[id].Active {
+		t.Fatal("not unfrozen")
+	}
+	if err := svc.Delete(context.Background(), id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !repo.store[id].Deleted {
+		t.Fatal("not deleted")
 	}
 }


### PR DESCRIPTION
## Summary
- add Freeze, Unfreeze and Delete methods to `promotion.Service`
- update promotion repository interface for status and delete updates
- use service methods in referral callbacks
- extend promotion tests and handler stubs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688437982500832a8e3551b2c2c8b250