### PR TITLE
Handle unlimited promo codes with -1 uses

### DIFF
--- a/db/migrations/000012_update_unlimited_promocode.down.sql
+++ b/db/migrations/000012_update_unlimited_promocode.down.sql
@@ -1,0 +1,1 @@
+UPDATE promocode SET uses_left = 0 WHERE uses_left = -1;

--- a/db/migrations/000012_update_unlimited_promocode.up.sql
+++ b/db/migrations/000012_update_unlimited_promocode.up.sql
@@ -1,0 +1,1 @@
+UPDATE promocode SET uses_left = -1 WHERE uses_left = 0;

--- a/internal/adapter/telegram/handler/promo_mylist_handler_test.go
+++ b/internal/adapter/telegram/handler/promo_mylist_handler_test.go
@@ -42,7 +42,7 @@ func TestPromoMyListCallbackHandler_Filter(t *testing.T) {
 	repo := &stubPromoRepo{promos: []pg.Promocode{
 		{ID: 1, Code: "A1", UsesLeft: 1, CreatedBy: 1, Active: true},
 		{ID: 2, Code: "B1", UsesLeft: 0, CreatedBy: 1, Active: false},
-		{ID: 3, Code: "C1", UsesLeft: 0, CreatedBy: 1, Active: true, Deleted: true},
+		{ID: 3, Code: "C1", UsesLeft: 1, CreatedBy: 1, Active: true, Deleted: true},
 		{ID: 4, Code: "D1", UsesLeft: -1, CreatedBy: 1, Active: true},
 	}}
 
@@ -56,10 +56,10 @@ func TestPromoMyListCallbackHandler_Filter(t *testing.T) {
 
 	h.PromoMyListCallbackHandler(context.Background(), b, upd)
 
-	if strings.Contains(httpc.body, "C1") || strings.Contains(httpc.body, "D1") {
+	if strings.Contains(httpc.body, "C1") || strings.Contains(httpc.body, "B1") {
 		t.Fatalf("unexpected promo codes in list: %s", httpc.body)
 	}
-	if !strings.Contains(httpc.body, "A1") || !strings.Contains(httpc.body, "B1") {
+	if !strings.Contains(httpc.body, "A1") || !strings.Contains(httpc.body, "D1") {
 		t.Fatalf("expected promo codes missing: %s", httpc.body)
 	}
 }

--- a/internal/adapter/telegram/handler/referral.go
+++ b/internal/adapter/telegram/handler/referral.go
@@ -145,7 +145,7 @@ func (h *Handler) PromoMyListCallbackHandler(ctx context.Context, b *bot.Bot, up
 		if p.Deleted {
 			continue
 		}
-		if p.UsesLeft <= 0 && p.UsesLeft != 0 {
+		if p.UsesLeft == 0 {
 			continue
 		}
 		filtered = append(filtered, p)

--- a/internal/repository/pg/promocode.go
+++ b/internal/repository/pg/promocode.go
@@ -119,7 +119,7 @@ func (r *PromocodeRepository) FindByCreator(ctx context.Context, createdBy int64
 	sql, args, err := sq.Select("id", "code", "months", "type", "days", "amount", "uses_left", "created_by", "created_at", "active").
 		From("promocode").
 		Where(sq.Eq{"created_by": createdBy, "deleted": false}).
-		Where(sq.Or{sq.Gt{"uses_left": 0}, sq.Eq{"uses_left": 0}}).
+		Where(sq.Or{sq.Gt{"uses_left": 0}, sq.Eq{"uses_left": -1}}).
 		OrderBy("created_at DESC").
 		PlaceholderFormat(sq.Dollar).ToSql()
 	if err != nil {

--- a/internal/service/payment/payment.go
+++ b/internal/service/payment/payment.go
@@ -346,6 +346,9 @@ func (s PaymentService) CreatePromocode(ctx context.Context, customer *domaincus
 
 	code = code[1:24]
 
+	if uses == 0 {
+		uses = -1
+	}
 	_, err := s.promocodeRepository.Create(ctx, &pg.Promocode{
 		Code:      code,
 		Months:    months,
@@ -372,7 +375,7 @@ func (s PaymentService) ApplyPromocode(ctx context.Context, customer *domaincust
 	if !promo.Active || promo.Deleted {
 		return nil, ErrPromocodeExpired
 	}
-	if promo.UsesLeft <= 0 && promo.UsesLeft != 0 {
+	if promo.UsesLeft == 0 {
 		return nil, ErrPromocodeLimitExced
 	}
 	if promo.Type == 2 {
@@ -401,7 +404,7 @@ func (s PaymentService) ApplyPromocode(ctx context.Context, customer *domaincust
 		customer.ExpireAt = &user.ExpireAt
 	}
 
-	if promo.UsesLeft > 0 {
+	if promo.UsesLeft != -1 {
 		if err := s.promocodeRepository.DecrementUses(ctx, promo.ID); err != nil {
 			return nil, err
 		}

--- a/internal/service/promotion/service.go
+++ b/internal/service/promotion/service.go
@@ -35,6 +35,9 @@ func (s *Service) CreateSubscription(ctx context.Context, code string, days, lim
 			return "", err
 		}
 	}
+	if limit == 0 {
+		limit = -1
+	}
 	_, err := s.repo.Create(ctx, &pg.Promocode{
 		Code:      code,
 		Months:    0,
@@ -56,6 +59,9 @@ func (s *Service) CreateBalance(ctx context.Context, amount, limit int, createdB
 	code, err := generateCode()
 	if err != nil {
 		return "", err
+	}
+	if limit == 0 {
+		limit = -1
 	}
 	_, err = s.repo.Create(ctx, &pg.Promocode{
 		Code:      code,


### PR DESCRIPTION
## Summary
- update PaymentService to check uses correctly and skip decrements only for -1
- ensure promo creation uses -1 when limit argument is 0
- adjust filtering logic for promo listings
- update repository query to include unlimited codes
- migrate existing unlimited codes from 0 to -1
- update tests for new unlimited semantics

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68844a092170832aa22f46d7531a0449