### PR TITLE
Add subscription code generator

### DIFF
--- a/internal/service/promotion/service.go
+++ b/internal/service/promotion/service.go
@@ -3,6 +3,7 @@ package promotion
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 
 	"remnawave-tg-shop-bot/internal/repository/pg"
 )
@@ -30,7 +31,7 @@ func NewService(repo Repository) *Service {
 func (s *Service) CreateSubscription(ctx context.Context, code string, days, limit int, createdBy int64) (string, error) {
 	if code == "" {
 		var err error
-		code, err = generateCode()
+		code, err = generateSubscriptionCode()
 		if err != nil {
 			return "", err
 		}
@@ -101,4 +102,15 @@ func generateCode() (string, error) {
 		b[i] = codeAlphabet[int(b[i])%len(codeAlphabet)]
 	}
 	return string(b), nil
+}
+
+func generateSubscriptionCode() (string, error) {
+	b := make([]byte, 15)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = codeAlphabet[int(b[i])%len(codeAlphabet)]
+	}
+	return fmt.Sprintf("%s-%s-%s", string(b[:5]), string(b[5:10]), string(b[10:])), nil
 }

--- a/tests/promotion_service_test.go
+++ b/tests/promotion_service_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"remnawave-tg-shop-bot/internal/repository/pg"
@@ -60,6 +61,19 @@ func TestCreateBalanceCodeUnique(t *testing.T) {
 	}
 	if c1 == c2 {
 		t.Fatal("codes not unique")
+	}
+}
+
+func TestCreateSubscriptionRandomCodeFormat(t *testing.T) {
+	repo := &stubPromoRepo{}
+	svc := promotion.NewService(repo)
+	code, err := svc.CreateSubscription(context.Background(), "", 30, 1, 1)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := regexp.MustCompile(`^[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}$`)
+	if !want.MatchString(code) {
+		t.Fatalf("code format invalid: %s", code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- generate subscription codes in a `XXXXX-XXXXX-XXXXX` format
- use new generator when creating subscription promocodes without a code
- test the new code format

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68844e522294832aa03c73a8faf5bbb5