### PR TITLE
Support /start=ref_123 format

### DIFF
--- a/internal/adapter/telegram/handler/start.go
+++ b/internal/adapter/telegram/handler/start.go
@@ -25,6 +25,9 @@ func (h *Handler) StartCommandHandler(ctx context.Context, b *bot.Bot, update *m
 	defer cancel()
 
 	parts := strings.SplitN(update.Message.Text, " ", 2)
+	if len(parts) == 1 {
+		parts = strings.SplitN(update.Message.Text, "=", 2)
+	}
 	if len(parts) == 2 && strings.HasPrefix(parts[1], "ref_") {
 		h.handleReferralStart(ctxWithTime, b, update, strings.TrimPrefix(parts[1], "ref_"))
 		return


### PR DESCRIPTION
## Summary
- handle `/start=ref_...` format in start handler
- test referral parsing for space-separated and `=` separated arguments

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688453fdf2c0832a9c5f989421acb110