### PR TITLE
Refactor promo commands

### DIFF
--- a/internal/adapter/telegram/handler/promo_common.go
+++ b/internal/adapter/telegram/handler/promo_common.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
+	"remnawave-tg-shop-bot/internal/service/payment"
+)
+
+// handlePromoCommand processes promo related commands. If parseArgs is true, it
+// will attempt to apply a code passed as argument, otherwise it just prompts the
+// user to enter a promo code.
+func (h *Handler) handlePromoCommand(ctx context.Context, b *bot.Bot, update *models.Update, parseArgs bool) {
+	lang := update.Message.From.LanguageCode
+	customer, err := h.findOrCreateCustomer(ctx, update.Message.Chat.ID, lang)
+	if err != nil {
+		slog.Error("find or create customer", "err", err)
+		return
+	}
+
+	parts := strings.Fields(update.Message.Text)
+	if parseArgs && len(parts) > 1 {
+		h.applyPromocode(ctx, b, update.Message.Chat.ID, lang, customer, parts[1])
+		return
+	}
+
+	h.promptPromoActivation(ctx, b, update.Message.Chat.ID, lang)
+}
+
+// promptPromoActivation sets the state so the next text message is treated as a
+// promo code and asks user to enter it.
+func (h *Handler) promptPromoActivation(ctx context.Context, b *bot.Bot, chatID int64, lang string) {
+	h.expectPromo(chatID)
+	if _, err := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: h.translation.GetText(lang, "promo.activate.prompt")}); err != nil {
+		slog.Error("send promo activate prompt", "err", err)
+	}
+}
+
+// applyPromocode applies the provided promo code to the customer and replies
+// with the result.
+func (h *Handler) applyPromocode(ctx context.Context, b *bot.Bot, chatID int64, lang string, customer *domaincustomer.Customer, code string) {
+	promo, err := h.paymentService.ApplyPromocode(ctx, customer, code)
+	if err != nil {
+		var text string
+		switch {
+		case errors.Is(err, payment.ErrPromocodeNotFound):
+			text = h.translation.GetText(lang, "promo_not_found")
+		case errors.Is(err, payment.ErrPromocodeExpired):
+			text = h.translation.GetText(lang, "promo_expired")
+		case errors.Is(err, payment.ErrPromocodeLimitExced):
+			text = h.translation.GetText(lang, "promo_limit_reached")
+		default:
+			text = h.translation.GetText(lang, "promo_invalid")
+		}
+		if _, serr := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: text}); serr != nil {
+			slog.Error("send promo invalid", "err", serr)
+		}
+		return
+	}
+	if promo.Type == 2 {
+		if _, serr := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, ParseMode: models.ParseModeHTML, Text: fmt.Sprintf(h.translation.GetText(lang, "promo_balance_applied"), promo.Amount/100, int(customer.Balance))}); serr != nil {
+			slog.Error("send balance promo", "err", serr)
+		}
+		return
+	}
+
+	until := ""
+	if customer.ExpireAt != nil {
+		until = customer.ExpireAt.Format("02.01.2006 15:04")
+	}
+
+	if _, err := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: fmt.Sprintf(h.translation.GetText(lang, "promo_applied"), until)}); err != nil {
+		slog.Error("send promo applied", "err", err)
+	}
+}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -13,7 +13,7 @@ func (a *App) InitHandlers(h *handler.Handler) {
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/menu", bot.MatchTypeExact, h.MenuCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/help", bot.MatchTypeExact, h.HelpCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/promo", bot.MatchTypeExact, h.PromoCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
-	b.RegisterHandler(bot.HandlerTypeMessageText, "/promocode", bot.MatchTypePrefix, h.PromocodeCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
+	b.RegisterHandler(bot.HandlerTypeMessageText, "/promocode", bot.MatchTypeExact, h.PromocodeCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/connect", bot.MatchTypeExact, h.ConnectCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
 	b.RegisterHandler(bot.HandlerTypeMessageText, "/sync", bot.MatchTypeExact, h.SyncUsersCommandHandler, h.CreateCustomerIfNotExistMiddleware, handler.LogUpdateMiddleware)
 

--- a/tests/promocode_command_test.go
+++ b/tests/promocode_command_test.go
@@ -43,3 +43,22 @@ func TestPromocodeCommandHandler_NoArgs(t *testing.T) {
 		t.Fatal("state not set")
 	}
 }
+
+func TestPromoCommandHandler_NoArgs(t *testing.T) {
+	SetTestEnv(t)
+	tm := translation.GetInstance()
+	_ = tm.InitDefaultTranslations()
+	httpc := &stubHTTPPromoCmd{}
+	b, _ := bot.New("t", bot.WithHTTPClient(time.Second, httpc), bot.WithSkipGetMe())
+	h := handlerpkg.NewHandler(nil, nil, tm, &StubCustomerRepo{}, nil, nil, nil, nil, nil, nil)
+
+	upd := &models.Update{Message: &models.Message{Chat: models.Chat{ID: 1}, From: &models.User{ID: 1, LanguageCode: "ru"}, Text: "/promo"}}
+	h.PromoCommandHandler(context.Background(), b, upd)
+
+	if !strings.Contains(httpc.body, tm.GetText("ru", "promo.activate.prompt")) {
+		t.Fatalf("unexpected body: %s", httpc.body)
+	}
+	if !h.IsAwaitingPromo(1) {
+		t.Fatal("state not set")
+	}
+}


### PR DESCRIPTION
## Summary
- deduplicate promo command logic
- adjust `/promocode` handler to always open activation state
- register `/promocode` as exact command
- test unified behaviour for `/promo` and `/promocode`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68845d3ed1a0832aa4ed19eb280b1de1