### PR TITLE
Switch short link provider

### DIFF
--- a/internal/adapter/telegram/handler/other.go
+++ b/internal/adapter/telegram/handler/other.go
@@ -194,7 +194,7 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		slog.Error("find customer", "err", err)
 		return
 	}
-	api := "https://tinyurl.com/api-create.php?url=" + url.QueryEscape(*customer.SubscriptionLink)
+	api := "https://clck.ru/--?url=" + url.QueryEscape(*customer.SubscriptionLink)
 	client := http.Client{Timeout: 5 * time.Second}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, api, nil)
@@ -210,22 +210,8 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 				slog.Error("close body", "err", cerr)
 			}
 		}
-		alt := "https://is.gd/create.php?format=simple&url=" + url.QueryEscape(*customer.SubscriptionLink)
-		req, err = http.NewRequestWithContext(ctx, http.MethodGet, alt, nil)
-		if err != nil {
-			slog.Error("new alt request", "err", err)
-			return
-		}
-		resp, err = client.Do(req)
-		if err != nil || resp.StatusCode >= http.StatusBadRequest {
-			if resp != nil && resp.Body != nil {
-				if cerr := resp.Body.Close(); cerr != nil {
-					slog.Error("close body", "err", cerr)
-				}
-			}
-			slog.Error("shorten", "err", err)
-			return
-		}
+		slog.Error("shorten", "err", err)
+		return
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
@@ -237,7 +223,7 @@ func (h *Handler) ShortLinkCallbackHandler(ctx context.Context, b *bot.Bot, upda
 		slog.Error("read short url", "err", err)
 		return
 	}
-	shortURL := string(data)
+	shortURL := strings.TrimSpace(string(data))
 	h.shortMu.Lock()
 	h.shortLinks[customer.TelegramID] = append(h.shortLinks[customer.TelegramID], ShortLink{URL: shortURL, CreatedAt: time.Now()})
 	h.shortMu.Unlock()


### PR DESCRIPTION
## Summary
- switch short link API to clck.ru
- remove fallback logic and update tests accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68846f87b48c832a9627f9a0d70ea6ed

## Сводка от Sourcery

Переключить поставщика коротких ссылок на clck.ru, удалить резервный вариант на is.gd и соответствующим образом обновить тесты и обработку ответов.

Улучшения:
- Использовать конечную точку API clck.ru для генерации коротких ссылок
- Удалить логику резервного варианта для альтернативного сокращателя URL
- Обрезать пробелы из возвращаемого короткого URL

Тесты:
- Переименовать и упростить тест закрытия тела (body-closure test) для проверки единственного запроса в случае ошибки
- Обновить testRoundTripper, чтобы отразить поведение только при ошибках и проверить закрытие тела ответа

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch short link provider to clck.ru, remove fallback to is.gd, and update tests and response handling accordingly.

Enhancements:
- Use clck.ru API endpoint for generating short links
- Remove fallback logic to alternate URL shortener
- Trim whitespace from the returned short URL

Tests:
- Rename and simplify body-closure test to assert single request on error
- Update testRoundTripper to reflect error-only behavior and verify response body closure

</details>