### PR TITLE
Decode subscription links

### DIFF
--- a/tests/unit/handler/keys_handler_test.go
+++ b/tests/unit/handler/keys_handler_test.go
@@ -1,0 +1,90 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	handlerpkg "remnawave-tg-shop-bot/internal/adapter/telegram/handler"
+	domaincustomer "remnawave-tg-shop-bot/internal/domain/customer"
+	"remnawave-tg-shop-bot/internal/pkg/translation"
+	"remnawave-tg-shop-bot/tests/testutils"
+)
+
+type documentRecorder struct {
+	req  *http.Request
+	body []byte
+}
+
+func (d *documentRecorder) Do(req *http.Request) (*http.Response, error) {
+	d.req = req
+	b, _ := io.ReadAll(req.Body)
+	d.body = b
+	resp := &http.Response{StatusCode: http.StatusOK}
+	resp.Body = io.NopCloser(strings.NewReader(`{"ok":true,"result":{"message_id":1}}`))
+	resp.Header = make(http.Header)
+	resp.Request = req
+	return resp, nil
+}
+
+func TestKeysCallbackHandler_DecodeBase64(t *testing.T) {
+	trans := translation.GetInstance()
+	if err := trans.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("vmess://a\nvmess://b"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(encoded))
+	}))
+	defer srv.Close()
+
+	link := srv.URL
+	repo := &testutils.StubCustomerRepo{CustomerByTelegramID: &domaincustomer.Customer{TelegramID: 1, SubscriptionLink: &link}}
+
+	rec := &documentRecorder{}
+	b, err := bot.New("token", bot.WithHTTPClient(time.Second, rec), bot.WithSkipGetMe())
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+
+	h := handlerpkg.NewHandler(nil, nil, trans, repo, nil, nil, nil, nil, nil)
+
+	upd := &models.Update{CallbackQuery: &models.CallbackQuery{From: models.User{ID: 1, LanguageCode: "en"}, Message: models.MaybeInaccessibleMessage{InaccessibleMessage: &models.InaccessibleMessage{Chat: models.Chat{ID: 1}, MessageID: 1}}}}
+
+	h.KeysCallbackHandler(context.Background(), b, upd)
+
+	mediaType, params, err := mime.ParseMediaType(rec.req.Header.Get("Content-Type"))
+	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+		t.Fatalf("unexpected content type: %v", err)
+	}
+	mr := multipart.NewReader(bytes.NewReader(rec.body), params["boundary"])
+	var docData []byte
+	for {
+		part, errPart := mr.NextPart()
+		if errPart == io.EOF {
+			break
+		}
+		if errPart != nil {
+			t.Fatalf("read part: %v", errPart)
+		}
+		if part.FormName() == "document" {
+			docData, _ = io.ReadAll(part)
+			break
+		}
+	}
+	if string(docData) != "vmess://a\nvmess://b" {
+		t.Fatalf("unexpected file content: %q", docData)
+	}
+}


### PR DESCRIPTION
## Summary
- decode the subscription data if it's Base64
- ensure multiple links are newline-separated
- add unit test covering the decoding logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688474a4dc0c832a90eed66593180ac1

## Сводка от Sourcery

Декодирование входящих данных подписки (обработка как Base64-кодированных, так и необработанных текстовых данных), нормализация извлеченных ссылок в формат, разделенный символами новой строки, обновление обработчика Telegram для использования этой логики, а также добавление модульного теста для поведения декодирования.

Новые функции:
- Декодирование Base64-кодированных данных подписки и нормализация ссылок в список, разделенный символами новой строки

Улучшения:
- Интеграция логики декодирования подписки в `KeysCallbackHandler`

Тесты:
- Добавление модульного теста для проверки декодирования Base64 и нормализации с использованием символов новой строки в обработчике ключей

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decode incoming subscription payloads (handling both Base64-encoded and raw text), normalize the extracted links into newline-separated format, update the Telegram handler to use this logic, and add a unit test for the decoding behavior.

New Features:
- Decode Base64-encoded subscription data and normalize links to a newline-separated list

Enhancements:
- Integrate subscription decoding logic into the KeysCallbackHandler

Tests:
- Add unit test to verify Base64 decoding and newline normalization in the keys handler

</details>