### PR TITLE
Add promo codes submenu for admin panel

### DIFF
--- a/internal/adapter/telegram/handler/admin_promo.go
+++ b/internal/adapter/telegram/handler/admin_promo.go
@@ -50,6 +50,11 @@ func (h *Handler) AdminPromoCallbackHandler(ctx context.Context, b *bot.Bot, upd
 		_, _ = SafeEditMessageText(ctx, b, update.CallbackQuery.Message.Message, &bot.EditMessageTextParams{ChatID: chatID, MessageID: msgID, ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb}, Text: tm.GetText(lang, "admin_panel_button")})
 		return
 	}
+	if data == uimenu.CallbackPromoAdminMenuPromos {
+		kb := uimenu.BuildAdminPromoCodesMenu(lang)
+		_, _ = SafeEditMessageText(ctx, b, update.CallbackQuery.Message.Message, &bot.EditMessageTextParams{ChatID: chatID, MessageID: msgID, ReplyMarkup: models.InlineKeyboardMarkup{InlineKeyboard: kb}, Text: tm.GetText(lang, "admin_promo_codes_button")})
+		return
+	}
 	if state == nil {
 		return
 	}

--- a/internal/ui/menu/keyboard.go
+++ b/internal/ui/menu/keyboard.go
@@ -34,6 +34,7 @@ const (
 	CallbackPromoAdminSubMonths      = "promo_admin_sub_months"
 	CallbackPromoAdminSubLimit       = "promo_admin_sub_limit"
 	CallbackPromoAdminSubConfirm     = "promo_admin_sub_confirm"
+	CallbackPromoAdminMenuPromos     = "promo_admin_menu_promos"
 	CallbackPromoAdminBack           = "promo_admin_back"
 	CallbackPromoAdminCancel         = "promo_admin_cancel"
 )
@@ -117,9 +118,18 @@ func BuildPersonalCodesMenu(lang string) [][]models.InlineKeyboardButton {
 func BuildAdminPromoMenu(lang string) [][]models.InlineKeyboardButton {
 	tm := translation.GetInstance()
 	return [][]models.InlineKeyboardButton{
-		{{Text: tm.GetText(lang, "admin_promo_balance_button"), CallbackData: CallbackPromoAdminBalanceStart}},
-		{{Text: tm.GetText(lang, "admin_promo_sub_button"), CallbackData: CallbackPromoAdminSubStart}},
+		{{Text: tm.GetText(lang, "admin_promo_codes_button"), CallbackData: CallbackPromoAdminMenuPromos}},
 		{{Text: tm.GetText(lang, "back_button"), CallbackData: "start"}},
+	}
+}
+
+// BuildAdminPromoCodesMenu returns promo codes menu keyboard for admin section.
+func BuildAdminPromoCodesMenu(lang string) [][]models.InlineKeyboardButton {
+	tm := translation.GetInstance()
+	return [][]models.InlineKeyboardButton{
+		{{Text: tm.GetText(lang, "admin_promo_sub_button"), CallbackData: CallbackPromoAdminSubStart}},
+		{{Text: tm.GetText(lang, "admin_promo_balance_button"), CallbackData: CallbackPromoAdminBalanceStart}},
+		{{Text: tm.GetText(lang, "back_button"), CallbackData: CallbackPromoAdminMenu}},
 	}
 }
 

--- a/internal/ui/menu/keyboard_test.go
+++ b/internal/ui/menu/keyboard_test.go
@@ -99,3 +99,23 @@ func TestBuildPersonalCodesMenu(t *testing.T) {
 		t.Fatalf("buttons missing")
 	}
 }
+
+func TestBuildAdminPromoMenus(t *testing.T) {
+	tm := translation.GetInstance()
+	if err := tm.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+
+	kb := BuildAdminPromoMenu("en")
+	if len(kb) != 2 || kb[0][0].CallbackData != CallbackPromoAdminMenuPromos {
+		t.Fatalf("unexpected admin promo menu: %#v", kb)
+	}
+
+	kb = BuildAdminPromoCodesMenu("en")
+	if len(kb) != 3 ||
+		kb[0][0].CallbackData != CallbackPromoAdminSubStart ||
+		kb[1][0].CallbackData != CallbackPromoAdminBalanceStart ||
+		kb[2][0].CallbackData != CallbackPromoAdminMenu {
+		t.Fatalf("unexpected admin promo codes menu: %#v", kb)
+	}
+}

--- a/tests/admin_promo_handler_test.go
+++ b/tests/admin_promo_handler_test.go
@@ -70,6 +70,9 @@ func TestAdminPromoBalanceWizard(t *testing.T) {
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
+	h.AdminPromoCallbackHandler(ctx, b, upd)
+
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminBalanceStart
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 
@@ -100,6 +103,9 @@ func TestAdminPromoSubWizard(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextkey.IsAdminKey, true)
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
+	h.AdminPromoCallbackHandler(ctx, b, upd)
+
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminSubStart
@@ -136,6 +142,8 @@ func TestAdminPromoBalanceManualAmount(t *testing.T) {
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
 	h.AdminPromoCallbackHandler(ctx, b, upd)
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
+	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminBalanceStart
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminBalanceAmount + ":manual"
@@ -168,6 +176,8 @@ func TestAdminPromoBalanceManualLimit(t *testing.T) {
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
 	h.AdminPromoCallbackHandler(ctx, b, upd)
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
+	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminBalanceStart
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminBalanceAmount + ":100"
@@ -199,6 +209,8 @@ func TestAdminPromoSubCustomCodeManualLimit(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextkey.IsAdminKey, true)
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
+	h.AdminPromoCallbackHandler(ctx, b, upd)
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminSubStart
 	h.AdminPromoCallbackHandler(ctx, b, upd)
@@ -240,6 +252,8 @@ func TestAdminPromoSubCustomCodeInvalid(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextkey.IsAdminKey, true)
 
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenu
+	h.AdminPromoCallbackHandler(ctx, b, upd)
+	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminMenuPromos
 	h.AdminPromoCallbackHandler(ctx, b, upd)
 	upd.CallbackQuery.Data = uimenu.CallbackPromoAdminSubStart
 	h.AdminPromoCallbackHandler(ctx, b, upd)

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -107,6 +107,7 @@ traffic_limit: "├ 📊 Daily limit: <b>%s / %s</b>\n"
 traffic_total_used: "├ ⚡ Total used: <b>%s</b>\n"
 traffic_time_to_reset: '├ 🔄 Until reset: <b>%s</b>'
 admin_panel_button: "⚙️ Admin panel"
+admin_promo_codes_button: "🎁 Promo codes"
 admin_promo_balance_button: "💰 Balance promo"
 admin_promo_sub_button: "📅 Subscription promo"
 create_button: "✅ Create"

--- a/translations/ru.yml
+++ b/translations/ru.yml
@@ -118,6 +118,7 @@ traffic_limit: "├ 📊 Лимит в сутки: <b>%s / %s</b>\n"
 traffic_total_used: "├ ⚡ Всего использовано: <b>%s</b>\n"
 traffic_time_to_reset: '├ 🔄 До сброса трафика: <b>%s</b>'
 admin_panel_button: "⚙️ Админ-панель"
+admin_promo_codes_button: "🎁 Промокоды"
 admin_promo_balance_button: "💰 Промокод на баланс"
 admin_promo_sub_button: "📅 Промокод на подписку"
 create_button: "✅ Создать"


### PR DESCRIPTION
## Summary
- add `Promo codes` submenu in admin panel
- support new admin promo menu callbacks
- translate new `admin_promo_codes_button`
- update keyboard tests and handler tests for new menu

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688484dcb6c4832a9de73fde9c35cc0e