### PR TITLE
Fix admin promo wizard confirm layout

### DIFF
--- a/internal/ui/menu/keyboard.go
+++ b/internal/ui/menu/keyboard.go
@@ -152,9 +152,11 @@ func BuildAdminPromoBalanceWizardStep(lang string, step StepState) [][]models.In
 		}
 	case StepConfirm:
 		return [][]models.InlineKeyboardButton{
-			{{Text: tm.GetText(lang, "create_button"), CallbackData: CallbackPromoAdminBalanceConfirm}},
+			{
+				{Text: tm.GetText(lang, "create_button"), CallbackData: CallbackPromoAdminBalanceConfirm},
+				{Text: tm.GetText(lang, "cancel_button"), CallbackData: CallbackPromoAdminCancel},
+			},
 			{{Text: tm.GetText(lang, "back_button"), CallbackData: CallbackPromoAdminBack}},
-			{{Text: tm.GetText(lang, "cancel_button"), CallbackData: CallbackPromoAdminCancel}},
 		}
 	default:
 		return nil
@@ -184,9 +186,11 @@ func BuildAdminPromoSubWizardStep(lang string, step StepState) [][]models.Inline
 		}
 	case StepConfirm:
 		return [][]models.InlineKeyboardButton{
-			{{Text: tm.GetText(lang, "create_button"), CallbackData: CallbackPromoAdminSubConfirm}},
+			{
+				{Text: tm.GetText(lang, "create_button"), CallbackData: CallbackPromoAdminSubConfirm},
+				{Text: tm.GetText(lang, "cancel_button"), CallbackData: CallbackPromoAdminCancel},
+			},
 			{{Text: tm.GetText(lang, "back_button"), CallbackData: CallbackPromoAdminBack}},
-			{{Text: tm.GetText(lang, "cancel_button"), CallbackData: CallbackPromoAdminCancel}},
 		}
 	default:
 		return nil

--- a/internal/ui/menu/keyboard_test.go
+++ b/internal/ui/menu/keyboard_test.go
@@ -119,3 +119,41 @@ func TestBuildAdminPromoMenus(t *testing.T) {
 		t.Fatalf("unexpected admin promo codes menu: %#v", kb)
 	}
 }
+
+func TestBuildAdminPromoBalanceWizardStepConfirm(t *testing.T) {
+	tm := translation.GetInstance()
+	if err := tm.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+	kb := BuildAdminPromoBalanceWizardStep("en", StepConfirm)
+	if len(kb) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(kb))
+	}
+	if len(kb[0]) != 2 ||
+		kb[0][0].CallbackData != CallbackPromoAdminBalanceConfirm ||
+		kb[0][1].CallbackData != CallbackPromoAdminCancel {
+		t.Fatalf("unexpected first row: %#v", kb[0])
+	}
+	if len(kb[1]) != 1 || kb[1][0].CallbackData != CallbackPromoAdminBack {
+		t.Fatalf("unexpected second row: %#v", kb[1])
+	}
+}
+
+func TestBuildAdminPromoSubWizardStepConfirm(t *testing.T) {
+	tm := translation.GetInstance()
+	if err := tm.InitDefaultTranslations(); err != nil {
+		t.Fatalf("init translations: %v", err)
+	}
+	kb := BuildAdminPromoSubWizardStep("en", StepConfirm)
+	if len(kb) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(kb))
+	}
+	if len(kb[0]) != 2 ||
+		kb[0][0].CallbackData != CallbackPromoAdminSubConfirm ||
+		kb[0][1].CallbackData != CallbackPromoAdminCancel {
+		t.Fatalf("unexpected first row: %#v", kb[0])
+	}
+	if len(kb[1]) != 1 || kb[1][0].CallbackData != CallbackPromoAdminBack {
+		t.Fatalf("unexpected second row: %#v", kb[1])
+	}
+}


### PR DESCRIPTION
## Summary
- tweak confirm step keyboards for admin promo wizards
- add unit tests for confirm step layouts

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6884865e63a8832a819a327dea576fef